### PR TITLE
Modified Azure Service bus dependency in Startup

### DIFF
--- a/src/TransCelerate.SDR.Service/Services/ClinicalStudyServiceV2.cs
+++ b/src/TransCelerate.SDR.Service/Services/ClinicalStudyServiceV2.cs
@@ -624,11 +624,15 @@ namespace TransCelerate.SDR.Services.Services
         #region Azure ServiceBus
         private async Task PushMessageToServiceBus(ServiceBusMessageDto serviceBusMessageDto)
         {
-            ServiceBusSender sender = _serviceBusClient.CreateSender(Config.AzureServiceBusQueueName);
+            //Execute the service bus only when Service Bus ConnectionString and Queue name are available in the configuration
+            if (!String.IsNullOrWhiteSpace(Config.AzureServiceBusConnectionString) && !String.IsNullOrWhiteSpace(Config.AzureServiceBusQueueName))
+            {
+                ServiceBusSender sender = _serviceBusClient.CreateSender(Config.AzureServiceBusQueueName);
 
-            string jsonMessageString = JsonConvert.SerializeObject(serviceBusMessageDto);
-            ServiceBusMessage serializedMessage = new(jsonMessageString);
-            await sender.SendMessageAsync(serializedMessage);
+                string jsonMessageString = JsonConvert.SerializeObject(serviceBusMessageDto);
+                ServiceBusMessage serializedMessage = new(jsonMessageString);
+                await sender.SendMessageAsync(serializedMessage);
+            }
         }
         #endregion
         #endregion

--- a/src/TransCelerate.SDR.WebApi/Startup.cs
+++ b/src/TransCelerate.SDR.WebApi/Startup.cs
@@ -1,3 +1,5 @@
+using Azure.Messaging.ServiceBus;
+using Moq;
 using FluentValidation.AspNetCore;
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -7,6 +9,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Versioning;
+using Microsoft.Azure.ServiceBus.Core;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -157,8 +160,16 @@ namespace TransCelerate.SDR.WebApi
             });
             services.AddAzureClients(clients =>
             {
-                clients.AddServiceBusClient(Config.AzureServiceBusConnectionString);
+                if(!String.IsNullOrWhiteSpace(Config.AzureServiceBusConnectionString))
+                {
+                    clients.AddServiceBusClient(Config.AzureServiceBusConnectionString);
+                }
             });
+            //The below service dependency will be added only if there is no connection string in the configuration for Azure Service Bus
+            if (String.IsNullOrWhiteSpace(Config.AzureServiceBusConnectionString))
+            {
+                services.AddTransient<ServiceBusClient>(x => Mock.Of<ServiceBusClient>());
+            }
         }
 
         /// <summary>

--- a/src/TransCelerate.SDR.WebApi/TransCelerate.SDR.WebApi.csproj
+++ b/src/TransCelerate.SDR.WebApi/TransCelerate.SDR.WebApi.csproj
@@ -39,9 +39,11 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.15" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.2.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.6.3" />
     <PackageReference Include="Microsoft.Identity.Web" Version="2.5.0" />
     <PackageReference Include="Microsoft.Identity.Web.MicrosoftGraph" Version="2.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />


### PR DESCRIPTION
Modified Azure Service bus dependency to create Mock service when the connection string for Azure service bus is not available in the configuration.
This change is done to run the application without having an instance of Azure Service Bus.

https://github.com/transcelerate/ddf-sdr-backlog/issues/699