### PR TITLE
US-730 Addressing review comments for GET AuditTrail and GET StudyDesign API endpoints

### DIFF
--- a/src/TransCelerate.SDR.Core/DTO/Common/AuditTrailResponseDto.cs
+++ b/src/TransCelerate.SDR.Core/DTO/Common/AuditTrailResponseDto.cs
@@ -7,6 +7,6 @@ namespace TransCelerate.SDR.Core.DTO.Common
     public class AuditTrailResponseDto
     {
         public string StudyId { get; set; }
-        public List<AuditTrailResponseWithLinksDto> AuditTrail { get; set; }
+        public List<AuditTrailResponseWithLinksDto> RevisionHistory { get; set; }
     }
 }

--- a/src/TransCelerate.SDR.Core/DTO/Common/LinksDto.cs
+++ b/src/TransCelerate.SDR.Core/DTO/Common/LinksDto.cs
@@ -6,7 +6,7 @@ namespace TransCelerate.SDR.Core.DTO.Common
     public class LinksDto
     {
         public string StudyDefinitions { get; set; }
-        public string AuditTrail { get; set; }
+        public string RevisionHistory { get; set; }
 
         public List<StudyDesignLinks> StudyDesigns { get; set; }
     }
@@ -20,7 +20,7 @@ namespace TransCelerate.SDR.Core.DTO.Common
     public class LinksForUIDto
     {
         public string StudyDefinitions { get; set; }
-        public string AuditTrail { get; set; }
+        public string RevisionHistory { get; set; }
 
         public List<StudyDesignLinks> StudyDesigns { get; set; }
 
@@ -30,7 +30,7 @@ namespace TransCelerate.SDR.Core.DTO.Common
     public class LinksEndpointDto
     {
         public string StudyDefinitions { get; set; }
-        public string AuditTrail { get; set; }
+        public string RevisionHistory { get; set; }
         [JsonProperty(nameof(SoA))]
         public string SoA { get; set; }
     }

--- a/src/TransCelerate.SDR.Core/Utilities/Common/Route.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Common/Route.cs
@@ -100,7 +100,7 @@
         #region Common Routes
         public const string GetRawJson = "studydefinitions/{studyId}/rawdata";
         public const string GetApiUsdmMapping = "versions";
-        public const string GetAudiTrail = "studydefinitions/{studyId}/audittrail";
+        public const string GetRevisionHistory = "studydefinitions/{studyId}/revisionhistory";
         public const string SearchStudyTitle = "studydefinitions/searchstudytitle";
         public const string GetStudyHistory = "studydefinitions/history";
         public const string CommonSearch = "studydefinitions/search";

--- a/src/TransCelerate.SDR.Core/Utilities/Helpers/LinksHelper.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Helpers/LinksHelper.cs
@@ -11,7 +11,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers
         {
             LinksDto links = new()
             {
-                AuditTrail = $"/studydefinitions/{studyId}/audittrail"
+                RevisionHistory = $"/studydefinitions/{studyId}/revisionhistory"
             };
             if (usdmVersion == Constants.USDMVersions.MVP)
             {
@@ -30,7 +30,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers
         {
             LinksDto links = new()
             {
-                AuditTrail = $"/studydefinitions/{studyId}/audittrail"
+                RevisionHistory = $"/studydefinitions/{studyId}/revisionhistory"
             };
             if (usdmVersion == Constants.USDMVersions.MVP)
             {
@@ -76,7 +76,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers
                         {
                             StudyDesignId = designId,
                             StudyDesignLink = $"/{ApiUsdmVersionMapping.SDRVersions.Where(x => x.UsdmVersions.Contains(usdmVersion)).Select(x => x.ApiVersion).First()}" +
-                                              $"/studydesigns?study_uuid={studyId}&sdruploadversion={sdruploadversion}&studydesign_uuid={designId}"
+                                              $"/studydesigns?studyid={studyId}&sdruploadversion={sdruploadversion}&studydesignid={designId}"
                         });
                     }
                 });
@@ -90,7 +90,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers
         {
             LinksForUIDto links = new()
             {
-                AuditTrail = $"/studydefinitions/{studyId}/audittrail"
+                RevisionHistory = $"/studydefinitions/{studyId}/revisionhistory"
             };
             if (usdmVersion == Constants.USDMVersions.MVP)
             {
@@ -112,7 +112,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers
         {
             LinksEndpointDto links = new()
             {
-                AuditTrail = $"/studydefinitions/{studyId}/audittrail"
+                RevisionHistory = $"/studydefinitions/{studyId}/revisionhistory"
             };
             if (usdmVersion == Constants.USDMVersions.MVP)
             {

--- a/src/TransCelerate.SDR.Service/Services/CommonServices.cs
+++ b/src/TransCelerate.SDR.Service/Services/CommonServices.cs
@@ -166,7 +166,7 @@ namespace TransCelerate.SDR.Services.Services
                 Links = new
                 {
                     links.StudyDefinitions,
-                    links.AuditTrail
+                    links.RevisionHistory
                 },
             };
             List<StudyDesignDto> studyeCPTDtos = new();
@@ -315,7 +315,7 @@ namespace TransCelerate.SDR.Services.Services
                     AuditTrailResponseDto getStudyAuditDto = new()
                     {
                         StudyId = studyId,
-                        AuditTrail = auditTrailDtoList
+                        RevisionHistory = auditTrailDtoList
                     };
 
                     return getStudyAuditDto;

--- a/src/TransCelerate.SDR.UnitTesting/ControllerUnitTesting/CommonControllerunitTesting.cs
+++ b/src/TransCelerate.SDR.UnitTesting/ControllerUnitTesting/CommonControllerunitTesting.cs
@@ -336,7 +336,7 @@ namespace TransCelerate.SDR.UnitTesting.ControllerUnitTesting
             AuditTrailResponseDto auditTrailResponseDto = new()
             {
                 StudyId = data.ClinicalStudy.ToString(),
-                AuditTrail = new List<AuditTrailResponseWithLinksDto> { new AuditTrailResponseWithLinksDto { EntryDateTime = DateTime.Now.AddDays(-1), SDRUploadVersion = 1 }, new AuditTrailResponseWithLinksDto { EntryDateTime = DateTime.Now, SDRUploadVersion = 2 } }
+                RevisionHistory = new List<AuditTrailResponseWithLinksDto> { new AuditTrailResponseWithLinksDto { EntryDateTime = DateTime.Now.AddDays(-1), SDRUploadVersion = 1 }, new AuditTrailResponseWithLinksDto { EntryDateTime = DateTime.Now, SDRUploadVersion = 2 } }
             };
 
             _mockCommonService.Setup(x => x.GetAuditTrail(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<LoggedInUser>()))

--- a/src/TransCelerate.SDR.WebApi/Controllers/ClinicalStudyV2Controller.cs
+++ b/src/TransCelerate.SDR.WebApi/Controllers/ClinicalStudyV2Controller.cs
@@ -109,7 +109,7 @@ namespace TransCelerate.SDR.WebApi.Controllers
         /// GET Study Designs of a Study
         /// </summary>
         /// <param name="studyId">Study ID</param>
-        /// <param name="studydesignId">Study Design ID</param>
+        /// <param name="studyDesignId">Study Design ID</param>
         /// <param name="sdruploadversion">Version of study</param>
         /// <param name="listofelements">List of study design elements with comma separated values</param>
         /// <param name="usdmVersion">USDM Version</param>
@@ -123,7 +123,7 @@ namespace TransCelerate.SDR.WebApi.Controllers
         [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(ErrorModel))]
         [SwaggerResponse(StatusCodes.Status404NotFound, Type = typeof(ErrorModel))]
         [Produces("application/json")]
-        public async Task<IActionResult> GetStudyDesigns(string studyId, int sdruploadversion, string studydesignId, string listofelements,
+        public async Task<IActionResult> GetStudyDesigns(string studyId, int sdruploadversion, string studyDesignId, string listofelements,
                                                   [FromHeader(Name = IdFieldPropertyName.Common.UsdmVersion)][BindRequired] string usdmVersion)
         {
             try
@@ -131,14 +131,14 @@ namespace TransCelerate.SDR.WebApi.Controllers
                 _logger.LogInformation($"Started Controller : {nameof(ClinicalStudyV2Controller)}; Method : {nameof(GetStudyDesigns)};");
                 if (!String.IsNullOrWhiteSpace(studyId))
                 {
-                    _logger.LogInformation($"Inputs : study_uuid = {studyId}; sdruploadversion = {sdruploadversion}; listofelements: {listofelements}; studydesign_uuid: {studydesignId}");
+                    _logger.LogInformation($"Inputs : study_uuid = {studyId}; sdruploadversion = {sdruploadversion}; listofelements: {listofelements}; studydesign_uuid: {studyDesignId}");
 
                     if (!_helper.AreValidStudyDesignElements(listofelements, out string[] listofelementsArray))
                         return BadRequest(new JsonResult(ErrorResponseHelper.BadRequest(Constants.ErrorMessages.StudyDesignElementNotValid)).Value);
 
                     LoggedInUser user = LoggedInUserHelper.GetLoggedInUser(User);
 
-                    var study = await _clinicalStudyService.GetStudyDesigns(studyId, studydesignId, sdruploadversion, user, listofelementsArray).ConfigureAwait(false);
+                    var study = await _clinicalStudyService.GetStudyDesigns(studyId, studyDesignId, sdruploadversion, user, listofelementsArray).ConfigureAwait(false);
 
                     if (study == null)
                     {

--- a/src/TransCelerate.SDR.WebApi/Controllers/ClinicalStudyV2Controller.cs
+++ b/src/TransCelerate.SDR.WebApi/Controllers/ClinicalStudyV2Controller.cs
@@ -108,8 +108,8 @@ namespace TransCelerate.SDR.WebApi.Controllers
         /// <summary>
         /// GET Study Designs of a Study
         /// </summary>
-        /// <param name="study_uuid">Study ID</param>
-        /// <param name="studydesign_uuid">Study Design ID</param>
+        /// <param name="studyId">Study ID</param>
+        /// <param name="studydesignId">Study Design ID</param>
         /// <param name="sdruploadversion">Version of study</param>
         /// <param name="listofelements">List of study design elements with comma separated values</param>
         /// <param name="usdmVersion">USDM Version</param>
@@ -123,22 +123,22 @@ namespace TransCelerate.SDR.WebApi.Controllers
         [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(ErrorModel))]
         [SwaggerResponse(StatusCodes.Status404NotFound, Type = typeof(ErrorModel))]
         [Produces("application/json")]
-        public async Task<IActionResult> GetStudyDesigns(string study_uuid, int sdruploadversion, string studydesign_uuid, string listofelements,
+        public async Task<IActionResult> GetStudyDesigns(string studyId, int sdruploadversion, string studydesignId, string listofelements,
                                                   [FromHeader(Name = IdFieldPropertyName.Common.UsdmVersion)][BindRequired] string usdmVersion)
         {
             try
             {
                 _logger.LogInformation($"Started Controller : {nameof(ClinicalStudyV2Controller)}; Method : {nameof(GetStudyDesigns)};");
-                if (!String.IsNullOrWhiteSpace(study_uuid))
+                if (!String.IsNullOrWhiteSpace(studyId))
                 {
-                    _logger.LogInformation($"Inputs : study_uuid = {study_uuid}; sdruploadversion = {sdruploadversion}; listofelements: {listofelements}; studydesign_uuid: {studydesign_uuid}");
+                    _logger.LogInformation($"Inputs : study_uuid = {studyId}; sdruploadversion = {sdruploadversion}; listofelements: {listofelements}; studydesign_uuid: {studydesignId}");
 
                     if (!_helper.AreValidStudyDesignElements(listofelements, out string[] listofelementsArray))
                         return BadRequest(new JsonResult(ErrorResponseHelper.BadRequest(Constants.ErrorMessages.StudyDesignElementNotValid)).Value);
 
                     LoggedInUser user = LoggedInUserHelper.GetLoggedInUser(User);
 
-                    var study = await _clinicalStudyService.GetStudyDesigns(study_uuid, studydesign_uuid, sdruploadversion, user, listofelementsArray).ConfigureAwait(false);
+                    var study = await _clinicalStudyService.GetStudyDesigns(studyId, studydesignId, sdruploadversion, user, listofelementsArray).ConfigureAwait(false);
 
                     if (study == null)
                     {

--- a/src/TransCelerate.SDR.WebApi/Controllers/CommonController.cs
+++ b/src/TransCelerate.SDR.WebApi/Controllers/CommonController.cs
@@ -214,7 +214,7 @@ namespace TransCelerate.SDR.WebApi.Controllers
         /// <response code="400">Bad Request</response>
         /// <response code="404">The Audit trail for the study is Not Found</response>
         [HttpGet]
-        [Route(Route.GetAudiTrail)]
+        [Route(Route.GetRevisionHistory)]
         [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(IEnumerable<AuditTrailResponseDto>))]
         [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(ErrorModel))]
         [SwaggerResponse(StatusCodes.Status404NotFound, Type = typeof(ErrorModel))]

--- a/src/TransCelerate.SDR.WebApi/TransCelerate.SDR.WebApi.md
+++ b/src/TransCelerate.SDR.WebApi/TransCelerate.SDR.WebApi.md
@@ -27,7 +27,7 @@
   - [GetAuditTrail(fromDate,toDate,studyId)](#M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-GetAuditTrail-System-String,System-DateTime,System-DateTime- 'TransCelerate.SDR.WebApi.Controllers.ClinicalStudyV2Controller.GetAuditTrail(System.String,System.DateTime,System.DateTime)')
   - [GetSOA(studyId,studyDesignId,sdruploadversion,studyWorkflowId)](#M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-GetSOA-System-String,System-String,System-String,System-Int32- 'TransCelerate.SDR.WebApi.Controllers.ClinicalStudyV2Controller.GetSOA(System.String,System.String,System.String,System.Int32)')
   - [GetStudy(studyId,sdruploadversion,listofelements,usdmVersion)](#M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-GetStudy-System-String,System-Int32,System-String,System-String- 'TransCelerate.SDR.WebApi.Controllers.ClinicalStudyV2Controller.GetStudy(System.String,System.Int32,System.String,System.String)')
-  - [GetStudyDesigns(studyId,studydesignId,sdruploadversion,listofelements,usdmVersion)](#M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-GetStudyDesigns-System-String,System-Int32,System-String,System-String,System-String- 'TransCelerate.SDR.WebApi.Controllers.ClinicalStudyV2Controller.GetStudyDesigns(System.String,System.Int32,System.String,System.String,System.String)')
+  - [GetStudyDesigns(studyId,studyDesignId,sdruploadversion,listofelements,usdmVersion)](#M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-GetStudyDesigns-System-String,System-Int32,System-String,System-String,System-String- 'TransCelerate.SDR.WebApi.Controllers.ClinicalStudyV2Controller.GetStudyDesigns(System.String,System.Int32,System.String,System.String,System.String)')
   - [GetStudyHistory(fromDate,toDate,studyTitle)](#M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-GetStudyHistory-System-DateTime,System-DateTime,System-String- 'TransCelerate.SDR.WebApi.Controllers.ClinicalStudyV2Controller.GetStudyHistory(System.DateTime,System.DateTime,System.String)')
   - [PostAllElements(studyDTO,usdmVersion)](#M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-PostAllElements-TransCelerate-SDR-Core-DTO-StudyV2-StudyDto,System-String- 'TransCelerate.SDR.WebApi.Controllers.ClinicalStudyV2Controller.PostAllElements(TransCelerate.SDR.Core.DTO.StudyV2.StudyDto,System.String)')
   - [PutStudy(studyDTO,usdmVersion,studyId)](#M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-PutStudy-TransCelerate-SDR-Core-DTO-StudyV2-StudyDto,System-String,System-String- 'TransCelerate.SDR.WebApi.Controllers.ClinicalStudyV2Controller.PutStudy(TransCelerate.SDR.Core.DTO.StudyV2.StudyDto,System.String,System.String)')
@@ -375,7 +375,7 @@ GET All Elements For a Study
 | usdmVersion | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | usdm-vreison header |
 
 <a name='M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-GetStudyDesigns-System-String,System-Int32,System-String,System-String,System-String-'></a>
-### GetStudyDesigns(studyId,studydesignId,sdruploadversion,listofelements,usdmVersion) `method`
+### GetStudyDesigns(studyId,studyDesignId,sdruploadversion,listofelements,usdmVersion) `method`
 
 ##### Summary
 
@@ -386,7 +386,7 @@ GET Study Designs of a Study
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | studyId | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Study ID |
-| studydesignId | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') | Study Design ID |
+| studyDesignId | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') | Study Design ID |
 | sdruploadversion | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Version of study |
 | listofelements | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | List of study design elements with comma separated values |
 | usdmVersion | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | USDM Version |

--- a/src/TransCelerate.SDR.WebApi/TransCelerate.SDR.WebApi.md
+++ b/src/TransCelerate.SDR.WebApi/TransCelerate.SDR.WebApi.md
@@ -27,7 +27,7 @@
   - [GetAuditTrail(fromDate,toDate,studyId)](#M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-GetAuditTrail-System-String,System-DateTime,System-DateTime- 'TransCelerate.SDR.WebApi.Controllers.ClinicalStudyV2Controller.GetAuditTrail(System.String,System.DateTime,System.DateTime)')
   - [GetSOA(studyId,studyDesignId,sdruploadversion,studyWorkflowId)](#M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-GetSOA-System-String,System-String,System-String,System-Int32- 'TransCelerate.SDR.WebApi.Controllers.ClinicalStudyV2Controller.GetSOA(System.String,System.String,System.String,System.Int32)')
   - [GetStudy(studyId,sdruploadversion,listofelements,usdmVersion)](#M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-GetStudy-System-String,System-Int32,System-String,System-String- 'TransCelerate.SDR.WebApi.Controllers.ClinicalStudyV2Controller.GetStudy(System.String,System.Int32,System.String,System.String)')
-  - [GetStudyDesigns(study_uuid,studydesign_uuid,sdruploadversion,listofelements,usdmVersion)](#M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-GetStudyDesigns-System-String,System-Int32,System-String,System-String,System-String- 'TransCelerate.SDR.WebApi.Controllers.ClinicalStudyV2Controller.GetStudyDesigns(System.String,System.Int32,System.String,System.String,System.String)')
+  - [GetStudyDesigns(studyId,studydesignId,sdruploadversion,listofelements,usdmVersion)](#M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-GetStudyDesigns-System-String,System-Int32,System-String,System-String,System-String- 'TransCelerate.SDR.WebApi.Controllers.ClinicalStudyV2Controller.GetStudyDesigns(System.String,System.Int32,System.String,System.String,System.String)')
   - [GetStudyHistory(fromDate,toDate,studyTitle)](#M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-GetStudyHistory-System-DateTime,System-DateTime,System-String- 'TransCelerate.SDR.WebApi.Controllers.ClinicalStudyV2Controller.GetStudyHistory(System.DateTime,System.DateTime,System.String)')
   - [PostAllElements(studyDTO,usdmVersion)](#M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-PostAllElements-TransCelerate-SDR-Core-DTO-StudyV2-StudyDto,System-String- 'TransCelerate.SDR.WebApi.Controllers.ClinicalStudyV2Controller.PostAllElements(TransCelerate.SDR.Core.DTO.StudyV2.StudyDto,System.String)')
   - [PutStudy(studyDTO,usdmVersion,studyId)](#M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-PutStudy-TransCelerate-SDR-Core-DTO-StudyV2-StudyDto,System-String,System-String- 'TransCelerate.SDR.WebApi.Controllers.ClinicalStudyV2Controller.PutStudy(TransCelerate.SDR.Core.DTO.StudyV2.StudyDto,System.String,System.String)')
@@ -375,7 +375,7 @@ GET All Elements For a Study
 | usdmVersion | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | usdm-vreison header |
 
 <a name='M-TransCelerate-SDR-WebApi-Controllers-ClinicalStudyV2Controller-GetStudyDesigns-System-String,System-Int32,System-String,System-String,System-String-'></a>
-### GetStudyDesigns(study_uuid,studydesign_uuid,sdruploadversion,listofelements,usdmVersion) `method`
+### GetStudyDesigns(studyId,studydesignId,sdruploadversion,listofelements,usdmVersion) `method`
 
 ##### Summary
 
@@ -385,8 +385,8 @@ GET Study Designs of a Study
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| study_uuid | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Study ID |
-| studydesign_uuid | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') | Study Design ID |
+| studyId | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Study ID |
+| studydesignId | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') | Study Design ID |
 | sdruploadversion | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Version of study |
 | listofelements | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | List of study design elements with comma separated values |
 | usdmVersion | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | USDM Version |


### PR DESCRIPTION
- Changed AuditTrail endpoint to revision history.
- Changed query parameter from study_uuid to studyId for GET studyDesign endpoint
- Changed query parameter from studyDesign_uuid to studydesignId for GET studyDesign endpoint
- Changed the property name auditTrail -> revisionHistory in GET revision history endpoint
- Changed the property name and the links from auditTrail -> revisionHistory in the links section of all the responses.
- Changed the link for studyDesigns

https://github.com/transcelerate/ddf-sdr-backlog/issues/730