### PR TITLE
US-738 Streamline Search & Search Study Title API to update property names in sync with USDM(1.9)

### DIFF
--- a/src/TransCelerate.SDR.Core/DTO/Common/CommonStudyIdentifiersDto.cs
+++ b/src/TransCelerate.SDR.Core/DTO/Common/CommonStudyIdentifiersDto.cs
@@ -2,7 +2,7 @@
 {
     public class CommonStudyIdentifiersDto
     {
-        [Newtonsoft.Json.JsonProperty(Utilities.Common.IdFieldPropertyName.StudyV1.Uuid)]
+        [Newtonsoft.Json.JsonProperty(Utilities.Common.IdFieldPropertyName.StudyV2.StudyIdentifierId)]
         public string Id { get; set; }
         public string StudyIdentifier { get; set; }
         public CommonOrganisationDto StudyIdentifierScope { get; set; }
@@ -10,7 +10,7 @@
 
     public class CommonOrganisationDto
     {
-        [Newtonsoft.Json.JsonProperty(Utilities.Common.IdFieldPropertyName.StudyV1.Uuid)]
+        [Newtonsoft.Json.JsonProperty(Utilities.Common.IdFieldPropertyName.StudyV2.OrganisationId)]
         public string Id { get; set; }
         public string OrganisationIdentifier { get; set; }
         public string OrganisationIdentifierScheme { get; set; }
@@ -20,7 +20,7 @@
 
     public class CommonCodeDto
     {
-        [Newtonsoft.Json.JsonProperty(Utilities.Common.IdFieldPropertyName.StudyV1.Uuid)]
+        [Newtonsoft.Json.JsonProperty(Utilities.Common.IdFieldPropertyName.StudyV2.CodeId)]
         public string Id { get; set; }
         public string Code { get; set; }
         public string CodeSystem { get; set; }

--- a/src/TransCelerate.SDR.Core/DTO/Common/SearchParametersDto.cs
+++ b/src/TransCelerate.SDR.Core/DTO/Common/SearchParametersDto.cs
@@ -2,7 +2,7 @@
 {
     public class SearchParametersDto
     {
-        public string StudyId { get; set; }
+        public string SponsorId { get; set; }
 
         public string StudyTitle { get; set; }
 

--- a/src/TransCelerate.SDR.Core/DTO/Common/SearchResponseDto.cs
+++ b/src/TransCelerate.SDR.Core/DTO/Common/SearchResponseDto.cs
@@ -12,8 +12,7 @@ namespace TransCelerate.SDR.Core.DTO.Common
     }
 
     public class SearchClinicalStudy
-    {
-        [JsonProperty(IdFieldPropertyName.StudyV1.Uuid)]
+    {        
         public string StudyId { get; set; }
         public string StudyTitle { get; set; }
         public CommonCodeDto StudyType { get; set; }
@@ -28,8 +27,7 @@ namespace TransCelerate.SDR.Core.DTO.Common
         public List<CommonStudyIndication> StudyIndications { get; set; }
     }
     public class CommonStudyIndication
-    {
-        [JsonProperty(IdFieldPropertyName.StudyV1.IndicationDesc)]
+    {        
         public string IndicationDescription { get; set; }
     }
 }

--- a/src/TransCelerate.SDR.Core/DTO/Common/SearchTitleParametersDto.cs
+++ b/src/TransCelerate.SDR.Core/DTO/Common/SearchTitleParametersDto.cs
@@ -3,7 +3,7 @@
     public class SearchTitleParametersDto
     {
         public string StudyTitle { get; set; }
-        public string StudyId { get; set; }
+        public string SponsorId { get; set; }
         public string FromDate { get; set; }
         public string ToDate { get; set; }
         public int PageSize { get; set; }

--- a/src/TransCelerate.SDR.Core/DTO/Common/SearchTitleResponseDto.cs
+++ b/src/TransCelerate.SDR.Core/DTO/Common/SearchTitleResponseDto.cs
@@ -16,8 +16,7 @@ namespace TransCelerate.SDR.Core.DTO.Common
     }
 
     public class SearchTitleClinicalStudy
-    {
-        [JsonProperty(IdFieldPropertyName.StudyV1.Uuid)]
+    {        
         public string StudyId { get; set; }
         public string StudyTitle { get; set; }
         public List<CommonStudyIdentifiersDto> StudyIdentifiers { get; set; }

--- a/src/TransCelerate.SDR.Core/Entities/Common/SearchParametersEntity.cs
+++ b/src/TransCelerate.SDR.Core/Entities/Common/SearchParametersEntity.cs
@@ -4,7 +4,7 @@ namespace TransCelerate.SDR.Core.Entities.Common
 {
     public class SearchParametersEntity
     {
-        public string StudyId { get; set; }
+        public string SponsorId { get; set; }
         public string StudyTitle { get; set; }
         public string Indication { get; set; }
         public string InterventionModel { get; set; }

--- a/src/TransCelerate.SDR.Core/Entities/Common/SearchTitleParametersEntity.cs
+++ b/src/TransCelerate.SDR.Core/Entities/Common/SearchTitleParametersEntity.cs
@@ -5,7 +5,7 @@ namespace TransCelerate.SDR.Core.Entities.Common
     public class SearchTitleParametersEntity
     {
         public string StudyTitle { get; set; }
-        public string StudyId { get; set; }
+        public string SponsorId { get; set; }
         public DateTime FromDate { get; set; }
         public DateTime ToDate { get; set; }
         public int PageSize { get; set; }

--- a/src/TransCelerate.SDR.DataAccess/Filters/DataFilterCommon.cs
+++ b/src/TransCelerate.SDR.DataAccess/Filters/DataFilterCommon.cs
@@ -120,13 +120,13 @@ namespace TransCelerate.SDR.DataAccess.Filters
                 filter &= builder.Where(x => x.ClinicalStudy.StudyTitle.ToLower().Contains(searchParameters.StudyTitle.ToLower()));
 
             //Filter for OrgCode
-            if (!String.IsNullOrWhiteSpace(searchParameters.StudyId))
+            if (!String.IsNullOrWhiteSpace(searchParameters.SponsorId))
             {
                 filter &= builder.Or(
                                      builder.And(
                                              builder.ElemMatch<BsonDocument>(Constants.DbFilter.StudyIdentifiers, new BsonDocument()
                                                      {
-                                                         { Constants.DbFilter.StudyIdentifierOrganisationIdentifier, new BsonRegularExpression($"/{searchParameters.StudyId}/i") } ,
+                                                         { Constants.DbFilter.StudyIdentifierOrganisationIdentifier, new BsonRegularExpression($"/{searchParameters.SponsorId}/i") } ,
                                                          { Constants.DbFilter.StudyIdentifierOrganisationTypeDecode, new BsonRegularExpression($"/{Constants.IdType.SPONSOR_ID_V1}$/i")}
                                                      }
                                                  )
@@ -134,7 +134,7 @@ namespace TransCelerate.SDR.DataAccess.Filters
                                      builder.And(
                                             builder.ElemMatch<BsonDocument>(Constants.DbFilter.StudyIdentifiers, new BsonDocument()
                                                      {
-                                                         { Constants.DbFilter.StudyIdentifierOrgCode, new BsonRegularExpression($"/{searchParameters.StudyId}/i") } ,
+                                                         { Constants.DbFilter.StudyIdentifierOrgCode, new BsonRegularExpression($"/{searchParameters.SponsorId}/i") } ,
                                                          { Constants.DbFilter.StudyIdentifierIdType, new BsonRegularExpression($"/{Constants.IdType.SPONSOR_ID}$/i")}
                                                      }
                                                  )
@@ -191,13 +191,13 @@ namespace TransCelerate.SDR.DataAccess.Filters
                 filter &= builder.Where(x => x.ClinicalStudy.StudyTitle.ToLower().Contains(searchParameters.StudyTitle.ToLower()));
 
             //Filter for OrgCode
-            if (!String.IsNullOrWhiteSpace(searchParameters.StudyId))
+            if (!String.IsNullOrWhiteSpace(searchParameters.SponsorId))
             {
                 filter &= builder.Or(
                      builder.And(
                              builder.ElemMatch<BsonDocument>(Constants.DbFilter.StudyIdentifiers, new BsonDocument()
                                      {
-                                                         { Constants.DbFilter.StudyIdentifierOrganisationIdentifier, new BsonRegularExpression($"/{searchParameters.StudyId}/i") } ,
+                                                         { Constants.DbFilter.StudyIdentifierOrganisationIdentifier, new BsonRegularExpression($"/{searchParameters.SponsorId}/i") } ,
                                                          { Constants.DbFilter.StudyIdentifierOrganisationTypeDecode, new BsonRegularExpression($"/{Constants.IdType.SPONSOR_ID_V1}$/i")}
                                      }
                                  )
@@ -205,7 +205,7 @@ namespace TransCelerate.SDR.DataAccess.Filters
                      builder.And(
                             builder.ElemMatch<BsonDocument>(Constants.DbFilter.StudyIdentifiers, new BsonDocument()
                                      {
-                                                         { Constants.DbFilter.StudyIdentifierOrgCode, new BsonRegularExpression($"/{searchParameters.StudyId}/i") } ,
+                                                         { Constants.DbFilter.StudyIdentifierOrgCode, new BsonRegularExpression($"/{searchParameters.SponsorId}/i") } ,
                                                          { Constants.DbFilter.StudyIdentifierIdType, new BsonRegularExpression($"/{Constants.IdType.SPONSOR_ID}$/i")}
                                      }
                                  )
@@ -289,13 +289,13 @@ namespace TransCelerate.SDR.DataAccess.Filters
                 filter &= builder.Where(x => x.ClinicalStudy.StudyTitle.ToLower().Contains(searchParameters.StudyTitle.ToLower()));
 
             //Filter for OrgCode
-            if (!String.IsNullOrWhiteSpace(searchParameters.StudyId))
+            if (!String.IsNullOrWhiteSpace(searchParameters.SponsorId))
             {
                 filter &= builder.Or(
                      builder.And(
                              builder.ElemMatch<BsonDocument>(Constants.DbFilter.StudyIdentifiers, new BsonDocument()
                                      {
-                                                         { Constants.DbFilter.StudyIdentifierOrganisationIdentifier, new BsonRegularExpression($"/{searchParameters.StudyId}/i") } ,
+                                                         { Constants.DbFilter.StudyIdentifierOrganisationIdentifier, new BsonRegularExpression($"/{searchParameters.SponsorId}/i") } ,
                                                          { Constants.DbFilter.StudyIdentifierOrganisationTypeDecode, new BsonRegularExpression($"/{Constants.IdType.SPONSOR_ID_V1}$/i")}
                                      }
                                  )
@@ -303,7 +303,7 @@ namespace TransCelerate.SDR.DataAccess.Filters
                      builder.And(
                             builder.ElemMatch<BsonDocument>(Constants.DbFilter.StudyIdentifiers, new BsonDocument()
                                      {
-                                                         { Constants.DbFilter.StudyIdentifierOrgCode, new BsonRegularExpression($"/{searchParameters.StudyId}/i") } ,
+                                                         { Constants.DbFilter.StudyIdentifierOrgCode, new BsonRegularExpression($"/{searchParameters.SponsorId}/i") } ,
                                                          { Constants.DbFilter.StudyIdentifierIdType, new BsonRegularExpression($"/{Constants.IdType.SPONSOR_ID}$/i")}
                                      }
                                  )

--- a/src/TransCelerate.SDR.RuleEngine/Common/SearchTitleParametersValidator.cs
+++ b/src/TransCelerate.SDR.RuleEngine/Common/SearchTitleParametersValidator.cs
@@ -5,17 +5,14 @@ using TransCelerate.SDR.Core.Utilities.Helpers;
 
 namespace TransCelerate.SDR.RuleEngine.Common
 {
-    public class SearchParametersValidator : AbstractValidator<SearchParametersDto>
+    public class SearchTitleParametersValidator : AbstractValidator<SearchTitleParametersDto>
     {
-        public SearchParametersValidator()
+        public SearchTitleParametersValidator()
         {
             RuleFor(x => x.StudyTitle)
                 .Matches(Constants.RegularExpressions.AlphaNumericsWithSpace)
                 .WithMessage(Constants.ValidationErrorMessage.AlphaNumericErrorMessage);
             RuleFor(x => x.SponsorId)
-                .Matches(Constants.RegularExpressions.AlphaNumericsWithSpace)
-                .WithMessage(Constants.ValidationErrorMessage.AlphaNumericErrorMessage);
-            RuleFor(x => x.Indication)
                 .Matches(Constants.RegularExpressions.AlphaNumericsWithSpace)
                 .WithMessage(Constants.ValidationErrorMessage.AlphaNumericErrorMessage);
             RuleFor(x => x.FromDate)

--- a/src/TransCelerate.SDR.RuleEngine/ValidationDependenciesCommon.cs
+++ b/src/TransCelerate.SDR.RuleEngine/ValidationDependenciesCommon.cs
@@ -15,6 +15,7 @@ namespace TransCelerate.SDR.RuleEngine.Common
         {
             // Validators            
             services.AddTransient<IValidator<SearchParametersDto>, SearchParametersValidator>();
+            services.AddTransient<IValidator<SearchTitleParametersDto>, SearchTitleParametersValidator>();
 
             return services;
         }

--- a/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/CommonClassesUnitTesting.cs
+++ b/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/CommonClassesUnitTesting.cs
@@ -609,12 +609,24 @@ namespace TransCelerate.SDR.UnitTesting
                 PageNumber = 1,
                 PageSize = 25,
                 Phase = "PHASE_1_TRAIL",
-                StudyId = "100",
+                SponsorId = "100",
                 FromDate = "",
                 ToDate = ""
             };
             TransCelerate.SDR.RuleEngine.Common.SearchParametersValidator searchValidator = new();
             Assert.IsTrue(searchValidator.Validate(searchParametersCommon).IsValid);
+
+            TransCelerate.SDR.Core.DTO.Common.SearchTitleParametersDto searchTitleParametersCommon = new()
+            {                
+                StudyTitle = "Umbrella",
+                PageNumber = 1,
+                PageSize = 25,                
+                SponsorId = "100",
+                FromDate = "",
+                ToDate = ""
+            };
+            TransCelerate.SDR.RuleEngine.Common.SearchTitleParametersValidator searchTitleParametersValidator = new();
+            Assert.IsTrue(searchTitleParametersValidator.Validate(searchTitleParametersCommon).IsValid);
         }
         #endregion
 
@@ -1009,7 +1021,7 @@ namespace TransCelerate.SDR.UnitTesting
                 SortBy = "version",
                 SortOrder = "asc",
                 GroupByStudyId = true,
-                StudyId = "100",
+                SponsorId = "100",
                 FromDate = DateTime.Now.AddDays(-5),
                 ToDate = DateTime.Now,
             };
@@ -1027,7 +1039,7 @@ namespace TransCelerate.SDR.UnitTesting
                 PageNumber = 1,
                 PageSize = 25,
                 Phase = "PHASE_1_TRAIL",
-                StudyId = "100",
+                SponsorId = "100",
                 FromDate = DateTime.Now.AddDays(-5),
                 ToDate = DateTime.Now,
                 Asc = true,

--- a/src/TransCelerate.SDR.UnitTesting/ControllerUnitTesting/CommonControllerunitTesting.cs
+++ b/src/TransCelerate.SDR.UnitTesting/ControllerUnitTesting/CommonControllerunitTesting.cs
@@ -600,7 +600,7 @@ namespace TransCelerate.SDR.UnitTesting.ControllerUnitTesting
                 StudyTitle = "Umbrella",
                 PageNumber = 1,
                 PageSize = 25,
-                StudyId = "100",
+                SponsorId = "100",
                 FromDate = DateTime.Now.AddDays(-5).ToString(),
                 ToDate = DateTime.Now.ToString()
             };
@@ -635,7 +635,7 @@ namespace TransCelerate.SDR.UnitTesting.ControllerUnitTesting
                 StudyTitle = "",
                 PageNumber = 0,
                 PageSize = 0,
-                StudyId = "",
+                SponsorId = "",
                 FromDate = "",
                 ToDate = ""
             };
@@ -676,7 +676,7 @@ namespace TransCelerate.SDR.UnitTesting.ControllerUnitTesting
                 StudyTitle = "",
                 PageNumber = 0,
                 PageSize = 0,
-                StudyId = "",
+                SponsorId = "",
                 FromDate = DateTime.Now.AddDays(1).ToString(),
                 ToDate = DateTime.Now.ToString()
             };
@@ -701,7 +701,7 @@ namespace TransCelerate.SDR.UnitTesting.ControllerUnitTesting
                 StudyTitle = "Study",
                 PageNumber = 0,
                 PageSize = 0,
-                StudyId = "",
+                SponsorId = "",
                 FromDate = "",
                 ToDate = ""
             };
@@ -826,7 +826,7 @@ namespace TransCelerate.SDR.UnitTesting.ControllerUnitTesting
                 PageNumber = 1,
                 PageSize = 25,
                 Phase = "PHASE_1_TRAIL",
-                StudyId = "100",
+                SponsorId = "100",
                 FromDate = DateTime.Now.AddDays(-5).ToString(),
                 ToDate = DateTime.Now.ToString()
             };
@@ -864,7 +864,7 @@ namespace TransCelerate.SDR.UnitTesting.ControllerUnitTesting
                 PageNumber = 0,
                 PageSize = 0,
                 Phase = "",
-                StudyId = "",
+                SponsorId = "",
                 FromDate = "",
                 ToDate = ""
             };
@@ -908,7 +908,7 @@ namespace TransCelerate.SDR.UnitTesting.ControllerUnitTesting
                 PageNumber = 0,
                 PageSize = 0,
                 Phase = "",
-                StudyId = "",
+                SponsorId = "",
                 FromDate = DateTime.Now.AddDays(1).ToString(),
                 ToDate = DateTime.Now.ToString()
             };
@@ -936,7 +936,7 @@ namespace TransCelerate.SDR.UnitTesting.ControllerUnitTesting
                 PageNumber = 0,
                 PageSize = 0,
                 Phase = "",
-                StudyId = "",
+                SponsorId = "",
                 FromDate = "",
                 ToDate = ""
             };

--- a/src/TransCelerate.SDR.UnitTesting/ServicesUnitTesting/CommonServicesUnitTesting.cs
+++ b/src/TransCelerate.SDR.UnitTesting/ServicesUnitTesting/CommonServicesUnitTesting.cs
@@ -628,7 +628,7 @@ namespace TransCelerate.SDR.UnitTesting.ServicesUnitTesting
                 StudyTitle = "Umbrella",
                 PageNumber = 1,
                 PageSize = 25,
-                StudyId = "100",
+                SponsorId = "100",
                 FromDate = DateTime.Now.AddDays(-5).ToString(),
                 ToDate = DateTime.Now.ToString(),
             };
@@ -902,7 +902,7 @@ namespace TransCelerate.SDR.UnitTesting.ServicesUnitTesting
                 PageNumber = 1,
                 PageSize = 25,
                 Phase = "PHASE_1_TRAIL",
-                StudyId = "100",
+                SponsorId = "100",
                 FromDate = DateTime.Now.AddDays(-5).ToString(),
                 ToDate = DateTime.Now.ToString(),
                 Asc = true,

--- a/src/TransCelerate.SDR.WebApi/Controllers/CommonController.cs
+++ b/src/TransCelerate.SDR.WebApi/Controllers/CommonController.cs
@@ -406,7 +406,7 @@ namespace TransCelerate.SDR.WebApi.Controllers
                 {
                     if (String.IsNullOrWhiteSpace(searchparameters.Indication)
                        && String.IsNullOrWhiteSpace(searchparameters.InterventionModel) && String.IsNullOrWhiteSpace(searchparameters.Phase)
-                       && String.IsNullOrWhiteSpace(searchparameters.StudyId) && String.IsNullOrWhiteSpace(searchparameters.StudyTitle)
+                       && String.IsNullOrWhiteSpace(searchparameters.SponsorId) && String.IsNullOrWhiteSpace(searchparameters.StudyTitle)
                        && String.IsNullOrWhiteSpace(searchparameters.FromDate) && String.IsNullOrWhiteSpace(searchparameters.ToDate))
                     {
                         return BadRequest(new JsonResult(ErrorResponseHelper.BadRequest(Constants.ValidationErrorMessage.AnyOneFieldError)).Value);
@@ -473,7 +473,7 @@ namespace TransCelerate.SDR.WebApi.Controllers
                 LoggedInUser user = LoggedInUserHelper.GetLoggedInUser(User);
                 if (searchparameters != null)
                 {
-                    if (String.IsNullOrWhiteSpace(searchparameters.StudyTitle) && String.IsNullOrWhiteSpace(searchparameters.StudyId)
+                    if (String.IsNullOrWhiteSpace(searchparameters.StudyTitle) && String.IsNullOrWhiteSpace(searchparameters.SponsorId)
                        && String.IsNullOrWhiteSpace(searchparameters.FromDate) && String.IsNullOrWhiteSpace(searchparameters.ToDate))
                     {
                         return BadRequest(new JsonResult(ErrorResponseHelper.BadRequest(Constants.ValidationErrorMessage.AnyOneFieldError)).Value);


### PR DESCRIPTION
1. Changed response of search and searchTitle APIs to match USDM 1.9.
2. Changed request body parameter studyId -> sponsorId in search and searchTitle APIs.
3. Added validations for Search Title API as in Search API.

https://github.com/transcelerate/ddf-sdr-backlog/issues/738
https://github.com/transcelerate/ddf-sdr-backlog/issues/745