### PR TITLE
Bug - 752 API- Version is not created if user updates the field "activities.previousActivityId"

### DIFF
--- a/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV2/HelperV2.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV2/HelperV2.cs
@@ -649,14 +649,12 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV2
 
                     if (y.DefinedProcedures is not null && y.DefinedProcedures.Any())
                     {
-                        y.PreviousActivityId = null;
-                        if (y.DefinedProcedures != null && y.DefinedProcedures.Any())
-                            y.DefinedProcedures.ForEach(procedure =>
-                            {
-                                procedure.Id = null;
-                                if (procedure.ProcedureCode is not null)
-                                    procedure.ProcedureCode.Id = null;
-                            });
+                        y.DefinedProcedures.ForEach(procedure =>
+                        {
+                            procedure.Id = null;
+                            if (procedure.ProcedureCode is not null)
+                                procedure.ProcedureCode.Id = null;
+                        });
                     }
                 });
             }


### PR DESCRIPTION
https://github.com/transcelerate/ddf-sdr-backlog/issues/752

The previousActivityId field was ignored along with the Id fields while comparing the changes for creating a new version of study. Removed previousActivityId field from ignoring when comparing to create a new verison.