### PR TITLE
Updated ordering logic for default sorting

### DIFF
--- a/src/TransCelerate.SDR.RuleEngine/StudyV3Rules/BiomedicalConceptCategoryValidator.cs
+++ b/src/TransCelerate.SDR.RuleEngine/StudyV3Rules/BiomedicalConceptCategoryValidator.cs
@@ -46,6 +46,13 @@ namespace TransCelerate.SDR.RuleEngineV3
                .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
                .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(BiomedicalConceptCategoryValidator), nameof(BiomedicalConceptCategoryDto.BcCategoryMemberIds)), ApplyConditionTo.AllValidators)
                .Must(x => UniquenessArrayValidator.ValidateStringList(x)).WithMessage(Constants.ValidationErrorMessage.UniquenessArrayError);
+
+            RuleFor(x => x.BcCategoryCode)
+               .Cascade(CascadeMode.Stop)
+               .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
+               .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
+               .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(BiomedicalConceptCategoryValidator), nameof(BiomedicalConceptCategoryDto.BcCategoryCode)), ApplyConditionTo.AllValidators)
+               .SetValidator(new AliasCodeValidator(_httpContextAccessor));
         }
     }
 }

--- a/src/TransCelerate.SDR.Service/Services/StudyServiceV3.cs
+++ b/src/TransCelerate.SDR.Service/Services/StudyServiceV3.cs
@@ -324,10 +324,9 @@ namespace TransCelerate.SDR.Services.Services
                         design.StudyScheduleTimelines.ForEach(scheduleTimeline =>
                         {
                             ScheduleTimelines studyTimelineSoA = _mapper.Map<ScheduleTimelines>(scheduleTimeline);
-                            //Get ordered Instances in reverse order
+                            //Get ordered Instances
                             List<ScheduledInstanceEntity> scheduledInstances = GetOrderedInstances(scheduleTimeline.ScheduleTimelineInstances);
-                            //Reverse it to get correct order
-                            scheduledInstances.Reverse();
+
                             var scheduleActivityInstances = scheduleTimeline.ScheduleTimelineInstances?.Select(x => (x as ScheduledActivityInstanceEntity))
                                                                          .Where(x => x != null).ToList();
                             
@@ -462,20 +461,25 @@ namespace TransCelerate.SDR.Services.Services
 
         public static List<ScheduledInstanceEntity> GetOrderedInstances(List<ScheduledInstanceEntity> scheduledInstances)
         {
-            if (scheduledInstances.Count(x => String.IsNullOrWhiteSpace(x.DefaultConditionId)) == 1)
+            if (scheduledInstances != null && scheduledInstances.Any())
             {
-                List<ScheduledInstanceEntity> instanceLinkedList = new()
+                if (scheduledInstances.Count(x => String.IsNullOrWhiteSpace(x.DefaultConditionId)) == 1)
                 {
-                    scheduledInstances.Where(x => String.IsNullOrWhiteSpace(x.DefaultConditionId)).FirstOrDefault()
-                };
-                for (int i = 1; i < scheduledInstances.Count; i++)
-                {
-                    if (scheduledInstances.Where(x => x.DefaultConditionId == instanceLinkedList[i - 1].Id).Any() && scheduledInstances.Where(x => x.DefaultConditionId == instanceLinkedList[i - 1].Id).Count() == 1)
-                        instanceLinkedList.Add(scheduledInstances.Where(x => x.DefaultConditionId == instanceLinkedList[i - 1].Id).First());
-                    else
-                        break;
+                    List<ScheduledInstanceEntity> instanceLinkedList = new()
+                    {
+                        scheduledInstances.Where(x => String.IsNullOrWhiteSpace(x.DefaultConditionId)).FirstOrDefault()
+                    };
+                    for (int i = 1; i < scheduledInstances.Count; i++)
+                    {
+                        if (scheduledInstances.Where(x => x.DefaultConditionId == instanceLinkedList[i - 1].Id).Any() && scheduledInstances.Where(x => x.DefaultConditionId == instanceLinkedList[i - 1].Id).Count() == 1)
+                            instanceLinkedList.Add(scheduledInstances.Where(x => x.DefaultConditionId == instanceLinkedList[i - 1].Id).First());
+                        else
+                            break;
+                    }
+                    //Reverse it to get correct order
+                    instanceLinkedList.Reverse();
+                    return instanceLinkedList.Count == scheduledInstances.Count ? instanceLinkedList : scheduledInstances;
                 }
-                return instanceLinkedList.Count == scheduledInstances.Count ? instanceLinkedList : scheduledInstances;
             }
             return scheduledInstances;
         }


### PR DESCRIPTION
Fixed an issue where the soa gave error when instances are not available.
https://github.com/transcelerate/ddf-sdr-backlog/issues/839