### PR TITLE
Rule engine improvements

### DIFF
--- a/src/TransCelerate.SDR.RuleEngine/Common/ValidationRuleHelpers.cs
+++ b/src/TransCelerate.SDR.RuleEngine/Common/ValidationRuleHelpers.cs
@@ -1,0 +1,48 @@
+using FluentValidation;
+using TransCelerate.SDR.Core.Utilities.Common;
+using TransCelerate.SDR.Core.Utilities.Helpers;
+
+namespace TransCelerate.SDR.RuleEngineV5.Common
+{
+    /// <summary>
+    /// Extension helper methods for validation rules
+    /// </summary>
+    public static class ValidationRuleHelpers
+    {
+        /// <summary>
+        /// Applies NotNull and NotEmpty validation rules conditionally based on conformance rules
+        /// </summary>
+        /// <typeparam name="T">The type being validated</typeparam>
+        /// <typeparam name="TProperty">The property type being validated</typeparam>
+        /// <param name="ruleBuilder">The rule builder</param>
+        /// <param name="usdmVersion">The USDM version from headers</param>
+        /// <param name="validatorClassName">The name of the validator class</param>
+        /// <param name="propertyName">The name of the property being validated</param>
+        /// <returns>Rule builder options for further chaining</returns>
+        public static IRuleBuilderOptions<T, TProperty> NotNullOrEmptyIfRequired<T, TProperty>(
+            this IRuleBuilder<T, TProperty> ruleBuilder,
+            string usdmVersion,
+            string validatorClassName,
+            string propertyName)
+        {
+            return ruleBuilder
+                .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
+                .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
+                .When(x => RulesHelper.GetConformanceRules(usdmVersion, validatorClassName, propertyName), ApplyConditionTo.AllValidators);
+        }
+
+        /// <summary>
+        /// Validates that InstanceType matches the validator name, without the "Validator" suffix.
+        /// </summary>
+        public static IRuleBuilderOptions<T, string> MustMatchValidatorInstanceType<T>(
+            this IRuleBuilder<T, string> ruleBuilder,
+            string validatorName)
+        {
+            var expectedInstanceType = validatorName.RemoveValidator();
+            
+            return ruleBuilder
+                .Must(x => expectedInstanceType == x)
+                .WithMessage(Constants.ValidationErrorMessage.InstanceTypeError);
+        }
+    }
+}

--- a/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/AdministrationValidator.cs
+++ b/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/AdministrationValidator.cs
@@ -18,73 +18,62 @@ namespace TransCelerate.SDR.RuleEngineV5
             _httpContextAccessor = httpContextAccessor;
 
             RuleFor(x => x.Id)
-               .Cascade(CascadeMode.Stop)
                .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
                .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
                .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Id)), ApplyConditionTo.AllValidators);
 
             RuleFor(x => x.InstanceType)
-              .Cascade(CascadeMode.Stop)
               .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
               .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
               .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.InstanceType)), ApplyConditionTo.AllValidators)
               .Must(x => this.GetType().Name.RemoveValidator() == x).WithMessage(Constants.ValidationErrorMessage.InstanceTypeError);
 
             RuleFor(x => x.Name)
-                .Cascade(CascadeMode.Stop)
                 .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
                 .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
                 .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Name)), ApplyConditionTo.AllValidators);
 
             RuleFor(x => x.Description)
-                .Cascade(CascadeMode.Stop)
                 .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
                 .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
                 .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Name)), ApplyConditionTo.AllValidators);
 
             RuleFor(x => x.Label)
-                .Cascade(CascadeMode.Stop)
                 .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
                 .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
                 .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Name)), ApplyConditionTo.AllValidators);
 
             RuleFor(x => x.Frequency)
-                .Cascade(CascadeMode.Stop)
                 .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
                 .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
                 .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Frequency)), ApplyConditionTo.AllValidators)
                 .SetValidator(new AliasCodeValidator(_httpContextAccessor));
 
             RuleFor(x => x.Route)
-                .Cascade(CascadeMode.Stop)
                 .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
                 .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
                 .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Route)), ApplyConditionTo.AllValidators)
                 .SetValidator(new AliasCodeValidator(_httpContextAccessor));
 
             RuleFor(x => x.Duration)
-                .Cascade(CascadeMode.Stop)
                 .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
                 .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
                 .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Duration)), ApplyConditionTo.AllValidators)
                 .SetValidator(new DurationValidator(_httpContextAccessor));
 
             RuleFor(x => x.Dose)
-                .Cascade(CascadeMode.Stop)
                 .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
                 .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
                 .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Dose)), ApplyConditionTo.AllValidators)
                 .SetValidator(new QuantityValidator(_httpContextAccessor));
 
             RuleFor(x => x.AdministrableProduct)
-                .Cascade(CascadeMode.Stop)
                 .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
                 .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
                 .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.AdministrableProduct)), ApplyConditionTo.AllValidators)
                 .SetValidator(new AdministrableProductValidator(_httpContextAccessor));
 
             RuleFor(x => x.Notes)
-                .Cascade(CascadeMode.Stop)
                 .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
                 .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
                 .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Notes)), ApplyConditionTo.AllValidators);
@@ -93,7 +82,6 @@ namespace TransCelerate.SDR.RuleEngineV5
                 .SetValidator(new CommentAnnotationValidator(_httpContextAccessor));
 
              RuleFor(x => x.MedicalDevice)
-                .Cascade(CascadeMode.Stop)
                 .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
                 .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
                 .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.MedicalDevice)), ApplyConditionTo.AllValidators)

--- a/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/AdministrationValidator.cs
+++ b/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/AdministrationValidator.cs
@@ -2,7 +2,7 @@ using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using TransCelerate.SDR.Core.DTO.StudyV5;
 using TransCelerate.SDR.Core.Utilities.Common;
-using TransCelerate.SDR.Core.Utilities.Helpers;
+using TransCelerate.SDR.RuleEngineV5.Common;
 
 namespace TransCelerate.SDR.RuleEngineV5
 {
@@ -16,75 +16,53 @@ namespace TransCelerate.SDR.RuleEngineV5
         public AdministrationValidator(IHttpContextAccessor httpContextAccessor)
         {
             _httpContextAccessor = httpContextAccessor;
+            var usdmVersion = _httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion];
+            var validatorName = nameof(AdministrationValidator);
 
             RuleFor(x => x.Id)
-               .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
-               .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
-               .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Id)), ApplyConditionTo.AllValidators);
+                .NotNullOrEmptyIfRequired(usdmVersion, validatorName, nameof(AdministrationDto.Id));
 
             RuleFor(x => x.InstanceType)
-              .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
-              .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
-              .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.InstanceType)), ApplyConditionTo.AllValidators)
-              .Must(x => this.GetType().Name.RemoveValidator() == x).WithMessage(Constants.ValidationErrorMessage.InstanceTypeError);
+                .NotNullOrEmptyIfRequired(usdmVersion, validatorName, nameof(AdministrationDto.InstanceType))
+                .MustMatchValidatorInstanceType(validatorName);
 
             RuleFor(x => x.Name)
-                .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
-                .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
-                .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Name)), ApplyConditionTo.AllValidators);
+                .NotNullOrEmptyIfRequired(usdmVersion, validatorName, nameof(AdministrationDto.Name));
 
             RuleFor(x => x.Description)
-                .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
-                .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
-                .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Name)), ApplyConditionTo.AllValidators);
+                .NotNullOrEmptyIfRequired(usdmVersion, validatorName, nameof(AdministrationDto.Description));
 
             RuleFor(x => x.Label)
-                .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
-                .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
-                .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Name)), ApplyConditionTo.AllValidators);
+                .NotNullOrEmptyIfRequired(usdmVersion, validatorName, nameof(AdministrationDto.Label));
 
             RuleFor(x => x.Frequency)
-                .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
-                .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
-                .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Frequency)), ApplyConditionTo.AllValidators)
+                .NotNullOrEmptyIfRequired(usdmVersion, validatorName, nameof(AdministrationDto.Frequency))
                 .SetValidator(new AliasCodeValidator(_httpContextAccessor));
 
             RuleFor(x => x.Route)
-                .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
-                .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
-                .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Route)), ApplyConditionTo.AllValidators)
+                .NotNullOrEmptyIfRequired(usdmVersion, validatorName, nameof(AdministrationDto.Route))
                 .SetValidator(new AliasCodeValidator(_httpContextAccessor));
 
             RuleFor(x => x.Duration)
-                .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
-                .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
-                .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Duration)), ApplyConditionTo.AllValidators)
+                .NotNullOrEmptyIfRequired(usdmVersion, validatorName, nameof(AdministrationDto.Duration))
                 .SetValidator(new DurationValidator(_httpContextAccessor));
 
             RuleFor(x => x.Dose)
-                .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
-                .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
-                .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Dose)), ApplyConditionTo.AllValidators)
+                .NotNullOrEmptyIfRequired(usdmVersion, validatorName, nameof(AdministrationDto.Dose))
                 .SetValidator(new QuantityValidator(_httpContextAccessor));
 
             RuleFor(x => x.AdministrableProduct)
-                .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
-                .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
-                .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.AdministrableProduct)), ApplyConditionTo.AllValidators)
+                .NotNullOrEmptyIfRequired(usdmVersion, validatorName, nameof(AdministrationDto.AdministrableProduct))
                 .SetValidator(new AdministrableProductValidator(_httpContextAccessor));
 
             RuleFor(x => x.Notes)
-                .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
-                .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
-                .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.Notes)), ApplyConditionTo.AllValidators);
+                .NotNullOrEmptyIfRequired(usdmVersion, validatorName, nameof(AdministrationDto.Notes));
 
             RuleForEach(x => x.Notes)
                 .SetValidator(new CommentAnnotationValidator(_httpContextAccessor));
 
-             RuleFor(x => x.MedicalDevice)
-                .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
-                .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
-                .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(AdministrationValidator), nameof(AdministrationDto.MedicalDevice)), ApplyConditionTo.AllValidators)
+            RuleFor(x => x.MedicalDevice)
+                .NotNullOrEmptyIfRequired(usdmVersion, validatorName, nameof(AdministrationDto.MedicalDevice))
                 .SetValidator(new MedicalDeviceValidator(_httpContextAccessor));
         }
     }

--- a/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/AdministrationValidator.cs
+++ b/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/AdministrationValidator.cs
@@ -2,7 +2,7 @@ using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using TransCelerate.SDR.Core.DTO.StudyV5;
 using TransCelerate.SDR.Core.Utilities.Common;
-using TransCelerate.SDR.RuleEngineV5.Common;
+using TransCelerate.SDR.RuleEngineV5.Utilities.Helpers;
 
 namespace TransCelerate.SDR.RuleEngineV5
 {

--- a/src/TransCelerate.SDR.RuleEngine/TransCelerate.SDR.RuleEngine.md
+++ b/src/TransCelerate.SDR.RuleEngine/TransCelerate.SDR.RuleEngine.md
@@ -210,6 +210,9 @@
   - [AddValidationDependenciesV4(services)](#M-TransCelerate-SDR-RuleEngineV4-ValidationDependenciesV4-AddValidationDependenciesV4-Microsoft-Extensions-DependencyInjection-IServiceCollection- 'TransCelerate.SDR.RuleEngineV4.ValidationDependenciesV4.AddValidationDependenciesV4(Microsoft.Extensions.DependencyInjection.IServiceCollection)')
 - [ValidationDependenciesV5](#T-TransCelerate-SDR-RuleEngineV5-ValidationDependenciesV5 'TransCelerate.SDR.RuleEngineV5.ValidationDependenciesV5')
   - [AddValidationDependenciesV5(services)](#M-TransCelerate-SDR-RuleEngineV5-ValidationDependenciesV5-AddValidationDependenciesV5-Microsoft-Extensions-DependencyInjection-IServiceCollection- 'TransCelerate.SDR.RuleEngineV5.ValidationDependenciesV5.AddValidationDependenciesV5(Microsoft.Extensions.DependencyInjection.IServiceCollection)')
+- [ValidationRuleHelpers](#T-TransCelerate-SDR-RuleEngineV5-Common-ValidationRuleHelpers 'TransCelerate.SDR.RuleEngineV5.Common.ValidationRuleHelpers')
+  - [MustMatchValidatorInstanceType\`\`1()](#M-TransCelerate-SDR-RuleEngineV5-Common-ValidationRuleHelpers-MustMatchValidatorInstanceType``1-FluentValidation-IRuleBuilder{``0,System-String},System-String- 'TransCelerate.SDR.RuleEngineV5.Common.ValidationRuleHelpers.MustMatchValidatorInstanceType``1(FluentValidation.IRuleBuilder{``0,System.String},System.String)')
+  - [NotNullOrEmptyIfRequired\`\`2(ruleBuilder,usdmVersion,validatorClassName,propertyName)](#M-TransCelerate-SDR-RuleEngineV5-Common-ValidationRuleHelpers-NotNullOrEmptyIfRequired``2-FluentValidation-IRuleBuilder{``0,``1},System-String,System-String,System-String- 'TransCelerate.SDR.RuleEngineV5.Common.ValidationRuleHelpers.NotNullOrEmptyIfRequired``2(FluentValidation.IRuleBuilder{``0,``1},System.String,System.String,System.String)')
 
 <a name='T-TransCelerate-SDR-RuleEngineV2-ActivityValidator'></a>
 ## ActivityValidator `type`
@@ -2497,3 +2500,52 @@ Add all the dependencies for validations
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | services | [Microsoft.Extensions.DependencyInjection.IServiceCollection](#T-Microsoft-Extensions-DependencyInjection-IServiceCollection 'Microsoft.Extensions.DependencyInjection.IServiceCollection') |  |
+
+<a name='T-TransCelerate-SDR-RuleEngineV5-Common-ValidationRuleHelpers'></a>
+## ValidationRuleHelpers `type`
+
+##### Namespace
+
+TransCelerate.SDR.RuleEngineV5.Common
+
+##### Summary
+
+Extension helper methods for validation rules
+
+<a name='M-TransCelerate-SDR-RuleEngineV5-Common-ValidationRuleHelpers-MustMatchValidatorInstanceType``1-FluentValidation-IRuleBuilder{``0,System-String},System-String-'></a>
+### MustMatchValidatorInstanceType\`\`1() `method`
+
+##### Summary
+
+Validates that InstanceType matches the validator name, without the "Validator" suffix.
+
+##### Parameters
+
+This method has no parameters.
+
+<a name='M-TransCelerate-SDR-RuleEngineV5-Common-ValidationRuleHelpers-NotNullOrEmptyIfRequired``2-FluentValidation-IRuleBuilder{``0,``1},System-String,System-String,System-String-'></a>
+### NotNullOrEmptyIfRequired\`\`2(ruleBuilder,usdmVersion,validatorClassName,propertyName) `method`
+
+##### Summary
+
+Applies NotNull and NotEmpty validation rules conditionally based on conformance rules
+
+##### Returns
+
+Rule builder options for further chaining
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| ruleBuilder | [FluentValidation.IRuleBuilder{\`\`0,\`\`1}](#T-FluentValidation-IRuleBuilder{``0,``1} 'FluentValidation.IRuleBuilder{``0,``1}') | The rule builder |
+| usdmVersion | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The USDM version from headers |
+| validatorClassName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The name of the validator class |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The name of the property being validated |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | The type being validated |
+| TProperty | The property type being validated |

--- a/src/TransCelerate.SDR.RuleEngine/Utilities/Helpers/ValidationRuleHelpers.cs
+++ b/src/TransCelerate.SDR.RuleEngine/Utilities/Helpers/ValidationRuleHelpers.cs
@@ -2,7 +2,7 @@ using FluentValidation;
 using TransCelerate.SDR.Core.Utilities.Common;
 using TransCelerate.SDR.Core.Utilities.Helpers;
 
-namespace TransCelerate.SDR.RuleEngineV5.Common
+namespace TransCelerate.SDR.RuleEngineV5.Utilities.Helpers
 {
     /// <summary>
     /// Extension helper methods for validation rules

--- a/src/TransCelerate.SDR.WebApi/Startup.cs
+++ b/src/TransCelerate.SDR.WebApi/Startup.cs
@@ -129,6 +129,7 @@ namespace TransCelerate.SDR.WebApi
 
             services.AddFluentValidationAutoValidation();
             ValidatorOptions.Global.DisplayNameResolver = (type, memberInfo, expression) => string.Concat(memberInfo.Name.Replace(" ", "")[..1]?.ToLower(), memberInfo.Name.Replace(" ", "").AsSpan(1));
+            ValidatorOptions.Global.DefaultRuleLevelCascadeMode = CascadeMode.Stop;
             services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
 
             //Enabling CORS


### PR DESCRIPTION
Suggestions for improvements to the existing rule engine code, to significantly reduce code duplication and verbosity. This should make it easier to work with when adding in lots of new rules.

Changes:

- Set `CascadeMode.Stop` as the global default rule setting, so that we don't have to add this to every single rule
- Extracted `usdmVersion` and `validatorName` once at the top of each validator, rather than repeating this for every rule
- `NotNullOrEmptyIfRequired` validation rule helper extension, which significantly reduces code duplication
- `MustMatchValidatorInstanceType` helper extension, which can be re-used by every `InstanceType` property validation

Note that I have only applied this to one validator for now (`AdministrationValidator`). Once these suggested changes have been reviewed and we are happy with them, we can go ahead and update all the V5 rules to use it.