### PR TITLE
Study Version rules

### DIFF
--- a/src/TransCelerate.SDR.Core/Utilities/Common/Constants.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Common/Constants.cs
@@ -174,6 +174,7 @@ namespace TransCelerate.SDR.Core.Utilities.Common
             public const string UsdmVersionMismatch = "usdmVersion value must be the same value mentioned in request header";
 
             public const string OfficialTitleError = "Atleast one Offical Title is required";
+            public const string StudyVersionHasOneClinicalStudySponsorOrganizationIdentifier = "Every study version must have exactly one study identifier with an identifier scope that references a clinical study sponsor organization";
         }
 
         public struct SuccessMessages

--- a/src/TransCelerate.SDR.RuleEngine/TransCelerate.SDR.RuleEngine.md
+++ b/src/TransCelerate.SDR.RuleEngine/TransCelerate.SDR.RuleEngine.md
@@ -188,6 +188,7 @@
 - [StudyValidator](#T-TransCelerate-SDR-RuleEngineV5-StudyValidator 'TransCelerate.SDR.RuleEngineV5.StudyValidator')
 - [StudyVersionValidator](#T-TransCelerate-SDR-RuleEngineV4-StudyVersionValidator 'TransCelerate.SDR.RuleEngineV4.StudyVersionValidator')
 - [StudyVersionValidator](#T-TransCelerate-SDR-RuleEngineV5-StudyVersionValidator 'TransCelerate.SDR.RuleEngineV5.StudyVersionValidator')
+  - [HasExactlyOneClinicalStudySponsorOrganizationIdentifier(studyIdentifiers)](#M-TransCelerate-SDR-RuleEngineV5-StudyVersionValidator-HasExactlyOneClinicalStudySponsorOrganizationIdentifier-System-Collections-Generic-List{TransCelerate-SDR-Core-DTO-StudyV5-StudyIdentifierDto}- 'TransCelerate.SDR.RuleEngineV5.StudyVersionValidator.HasExactlyOneClinicalStudySponsorOrganizationIdentifier(System.Collections.Generic.List{TransCelerate.SDR.Core.DTO.StudyV5.StudyIdentifierDto})')
 - [SubjectEnrollmentValidator](#T-TransCelerate-SDR-RuleEngineV4-SubjectEnrollmentValidator 'TransCelerate.SDR.RuleEngineV4.SubjectEnrollmentValidator')
 - [SubjectEnrollmentValidator](#T-TransCelerate-SDR-RuleEngineV5-SubjectEnrollmentValidator 'TransCelerate.SDR.RuleEngineV5.SubjectEnrollmentValidator')
 - [SubstanceValidator](#T-TransCelerate-SDR-RuleEngineV5-SubstanceValidator 'TransCelerate.SDR.RuleEngineV5.SubstanceValidator')
@@ -2245,6 +2246,26 @@ TransCelerate.SDR.RuleEngineV5
 ##### Summary
 
 This Class is the validator for Study
+
+<a name='M-TransCelerate-SDR-RuleEngineV5-StudyVersionValidator-HasExactlyOneClinicalStudySponsorOrganizationIdentifier-System-Collections-Generic-List{TransCelerate-SDR-Core-DTO-StudyV5-StudyIdentifierDto}-'></a>
+### HasExactlyOneClinicalStudySponsorOrganizationIdentifier(studyIdentifiers) `method`
+
+##### Summary
+
+Validates that there is exactly one study identifier with an identifier scope that references a clinical study sponsor organization.
+
+RuleID: DDF00005
+CheckId: CHK0012
+
+##### Returns
+
+True if exactly one clinical study sponsor organization identifier exists, otherwise false
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| studyIdentifiers | [System.Collections.Generic.List{TransCelerate.SDR.Core.DTO.StudyV5.StudyIdentifierDto}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.List 'System.Collections.Generic.List{TransCelerate.SDR.Core.DTO.StudyV5.StudyIdentifierDto}') | List of study identifiers to validate |
 
 <a name='T-TransCelerate-SDR-RuleEngineV4-SubjectEnrollmentValidator'></a>
 ## SubjectEnrollmentValidator `type`

--- a/src/TransCelerate.SDR.UnitTesting/ValidationRuleUnitTesting/V5/StudyVersionValidatorUnitTestingV5.cs
+++ b/src/TransCelerate.SDR.UnitTesting/ValidationRuleUnitTesting/V5/StudyVersionValidatorUnitTestingV5.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using TransCelerate.SDR.Core.DTO.StudyV5;
+using TransCelerate.SDR.RuleEngineV5;
+using TransCelerate.SDR.Core.Utilities.Common;
+
+namespace TransCelerate.SDR.UnitTesting.ValidationRuleUnitTesting
+{
+    [TestFixture]
+    public class StudyVersionValidatorUnitTestingV5
+    {
+        private StudyVersionValidator _studyVersionValidator;
+
+        private static StudyIdentifierDto CreateStudyIdentifier(string decode, int index = 1)
+        {
+            return new StudyIdentifierDto
+            {
+                Id = $"study-identifier-{index}",
+                Scope = new OrganizationDto
+                {
+                    Id = $"organization-{index}",
+                    Type = new CodeDto
+                    {
+                        Id = $"code-{index}",
+                        Decode = decode
+                    }
+                }
+            };
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            _studyVersionValidator = new StudyVersionValidator(null);
+        }
+
+        [TestFixture]
+        public class HaveOneClinicalStudySponsorOrganizationIdentifierTests : StudyVersionValidatorUnitTestingV5
+        {
+            [Test]
+            public void NullStudyIdentifierList_ReturnsFalse()
+            {
+                // Act
+                var result = StudyVersionValidator.HasExactlyOneClinicalStudySponsorOrganizationIdentifier(null);
+
+                // Assert
+                Assert.IsFalse(result);
+            }
+
+            [Test]
+            public void EmptyStudyIdentifierList_ReturnsFalse()
+            {
+                // Act
+                var result = StudyVersionValidator.HasExactlyOneClinicalStudySponsorOrganizationIdentifier(new List<StudyIdentifierDto>());
+
+                // Assert
+                Assert.IsFalse(result);
+            }
+            
+               [Test]
+            public void ExactlyOneSponsor_ReturnsTrue()
+            {
+                // Arrange
+                var studyIdentifiers = new List<StudyIdentifierDto>
+                {
+                    CreateStudyIdentifier(Constants.IdType.SPONSOR_ID_V1)
+                };
+
+                // Act
+                var result = StudyVersionValidator.HasExactlyOneClinicalStudySponsorOrganizationIdentifier(studyIdentifiers);
+
+                // Assert
+                Assert.IsTrue(result);
+            }
+
+            [Test]
+            public void MultipleSponsors_ReturnsFalse()
+            {
+                // Arrange
+                var studyIdentifiers = new List<StudyIdentifierDto>
+                {
+                    CreateStudyIdentifier(Constants.IdType.SPONSOR_ID_V1, 1),
+                    CreateStudyIdentifier(Constants.IdType.SPONSOR_ID_V1, 2)
+                };
+
+                // Act
+                var result = StudyVersionValidator.HasExactlyOneClinicalStudySponsorOrganizationIdentifier(studyIdentifiers);
+
+                // Assert
+                Assert.IsFalse(result);
+            }
+
+            [Test]
+            public void NoSponsor_ReturnsFalse()
+            {
+                // Arrange
+                var studyIdentifiers = new List<StudyIdentifierDto>
+                {
+                    CreateStudyIdentifier("OTHER_TYPE", 1),
+                    CreateStudyIdentifier("ANOTHER_TYPE", 2)
+                };
+
+                // Act
+                var result = StudyVersionValidator.HasExactlyOneClinicalStudySponsorOrganizationIdentifier(studyIdentifiers);
+
+                // Assert
+                Assert.IsFalse(result);
+            }
+
+            [Test]
+            public void OneSponsorAmongMultiple_ReturnsTrue()
+            {
+                // Arrange
+                var studyIdentifiers = new List<StudyIdentifierDto>
+                {
+                    CreateStudyIdentifier("OTHER_TYPE", 1),
+                    CreateStudyIdentifier(Constants.IdType.SPONSOR_ID_V1, 2),
+                    CreateStudyIdentifier("ANOTHER_TYPE", 3)
+                };
+
+                // Act
+                var result = StudyVersionValidator.HasExactlyOneClinicalStudySponsorOrganizationIdentifier(studyIdentifiers);
+
+                // Assert
+                Assert.IsTrue(result);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Draft review with only one rule implemented currently, just to check that the overall rule design/implementation looks good.

Rule ID: DDF00005

"Every study version must have exactly one study identifier with an identifier scope that references a clinical study sponsor organization"

The rule has been implemented as part of the RuleEngine validation, rather than the reference integrity check code. It has been implemented as a standalone function with unit tests, and then applied to the property using .Must(x => ...) from FluentValidation.