### PR TITLE
Model cross refs scopes

### DIFF
--- a/src/TransCelerate.SDR.Core/Utilities/Common/Constants.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Common/Constants.cs
@@ -378,7 +378,6 @@ namespace TransCelerate.SDR.Core.Utilities.Common
 			nameof(Core.DTO.StudyV5.StudyVersionDto.Rationale),
 			nameof(Core.DTO.StudyV5.StudyVersionDto.Amendments),
 			nameof(Core.DTO.StudyV5.StudyVersionDto.DateValues),
-			nameof(Core.DTO.StudyV5.StudyVersionDto.NarrativeContentItems),
 			nameof(Core.DTO.StudyV5.StudyVersionDto.Abbreviations),
 			nameof(Core.DTO.StudyV5.StudyVersionDto.Notes),
 			nameof(Core.DTO.StudyV5.StudyVersionDto.InstanceType)

--- a/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
@@ -64,7 +64,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                 {
                     foreach (string element in listofElementsArray)
                     {
-                        if (!Constants.StudyElementsV4.Select(x => x.ToLower()).Contains(element.ToLower()))
+                        if (!Constants.StudyElementsV5.Select(x => x.ToLower()).Contains(element.ToLower()))
                         {
                             isValid = false;
                             break;

--- a/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/HelperV2ClassesUnitTesting.cs
+++ b/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/HelperV2ClassesUnitTesting.cs
@@ -68,7 +68,11 @@ namespace TransCelerate.SDR.UnitTesting
         public void ApiBehaviourOptionsHelper()
         {
             ApiBehaviourOptionsHelper apiBehaviourOptionsHelper = new(_mockLogger);
-            ActionContext context = new();
+            ActionContext context = new()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
             var studyDto = GetDtoDataFromStaticJson();
             studyDto.Study = null;
             var httpContextAccessor = new Mock<IHttpContextAccessor>();
@@ -77,7 +81,6 @@ namespace TransCelerate.SDR.UnitTesting
             contextAccessor.Request.Headers["usdmVersion"] = usdmVersion;
             httpContextAccessor.Setup(_ => _.HttpContext).Returns(contextAccessor);
 
-
             StudyDefinitionsValidator studyDefinitionsValidator = new(httpContextAccessor.Object);
             var errors = studyDefinitionsValidator.Validate(studyDto).Errors;
             context.ModelState.AddModelError("study", errors[0].ErrorMessage);
@@ -85,7 +88,10 @@ namespace TransCelerate.SDR.UnitTesting
             Assert.IsInstanceOf(typeof(BadRequestObjectResult), response);
 
 
-            context.ModelState.Clear();
+            context = new()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
             studyDto = GetDtoDataFromStaticJson();
             studyDto.Study.StudyTitle = null;
 

--- a/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/HelperV3ClassesUnitTesting.cs
+++ b/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/HelperV3ClassesUnitTesting.cs
@@ -68,7 +68,11 @@ namespace TransCelerate.SDR.UnitTesting
         public void ApiBehaviourOptionsHelper()
         {
             ApiBehaviourOptionsHelper apiBehaviourOptionsHelper = new(_mockLogger);
-            ActionContext context = new();
+            ActionContext context = new()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
             var studyDto = GetDtoDataFromStaticJson();
             studyDto.Study = null;
             var httpContextAccessor = new Mock<IHttpContextAccessor>();
@@ -85,7 +89,10 @@ namespace TransCelerate.SDR.UnitTesting
             Assert.IsInstanceOf(typeof(BadRequestObjectResult), response);
 
 
-            context.ModelState.Clear();
+            context = new()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
             studyDto = GetDtoDataFromStaticJson();
             studyDto.Study.StudyTitle = null;
 

--- a/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/HelperV4ClassesUnitTesting.cs
+++ b/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/HelperV4ClassesUnitTesting.cs
@@ -63,7 +63,11 @@ namespace TransCelerate.SDR.UnitTesting
         public void ApiBehaviourOptionsHelper()
         {
             ApiBehaviourOptionsHelper apiBehaviourOptionsHelper = new(_mockLogger);
-            ActionContext context = new();
+            ActionContext context = new()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
             var studyDto = GetDtoDataFromStaticJson();
             studyDto.Study = null;
             var httpContextAccessor = new Mock<IHttpContextAccessor>();
@@ -80,7 +84,10 @@ namespace TransCelerate.SDR.UnitTesting
             Assert.IsInstanceOf(typeof(BadRequestObjectResult), response);
 
 
-            context.ModelState.Clear();
+            context = new()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
             studyDto = GetDtoDataFromStaticJson();
             studyDto.Study.Versions.FirstOrDefault().Titles = null;
 

--- a/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/HelperV5ClassesUnitTesting.cs
+++ b/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/HelperV5ClassesUnitTesting.cs
@@ -17,6 +17,8 @@ using TransCelerate.SDR.Core.Utilities.Common;
 using TransCelerate.SDR.Core.Utilities.Helpers;
 using TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5;
 using TransCelerate.SDR.DataAccess.Filters;
+using TransCelerate.SDR.RuleEngine.Common;
+using TransCelerate.SDR.RuleEngine.StudyV5Rules;
 using TransCelerate.SDR.RuleEngineV5;
 
 namespace TransCelerate.SDR.UnitTesting
@@ -62,7 +64,11 @@ namespace TransCelerate.SDR.UnitTesting
         public void ApiBehaviourOptionsHelper()
         {
             ApiBehaviourOptionsHelper apiBehaviourOptionsHelper = new(_mockLogger);
-            ActionContext context = new();
+            ActionContext context = new()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
             var studyDto = GetDtoDataFromStaticJson();
             studyDto.Study = null;
             var httpContextAccessor = new Mock<IHttpContextAccessor>();
@@ -71,7 +77,6 @@ namespace TransCelerate.SDR.UnitTesting
             contextAccessor.Request.Headers["usdmVersion"] = usdmVersion;
             httpContextAccessor.Setup(_ => _.HttpContext).Returns(contextAccessor);
 
-
             StudyDefinitionsValidator studyDefinitionsValidator = new(httpContextAccessor.Object);
             var errors = studyDefinitionsValidator.Validate(studyDto).Errors;
             context.ModelState.AddModelError("study", errors[0].ErrorMessage);
@@ -79,7 +84,10 @@ namespace TransCelerate.SDR.UnitTesting
             Assert.IsInstanceOf(typeof(BadRequestObjectResult), response);
 
 
-            context.ModelState.Clear();
+            context = new()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
             studyDto = GetDtoDataFromStaticJson();
             studyDto.Study.Versions.FirstOrDefault().Titles = null;
 

--- a/src/TransCelerate.SDR.UnitTesting/Data/StudyDataV5.json
+++ b/src/TransCelerate.SDR.UnitTesting/Data/StudyDataV5.json
@@ -257,47 +257,6 @@
             "extensionAttributes": [],
             "text": "H2Q-MC-LZZT",
             "scopeId": "Organization_1",
-            "scope": {
-              "id": "Organization_1",
-              "extensionAttributes": [],
-              "name": "LILLY",
-              "label": "Eli Lilly",
-              "type": {
-                "id": "Code_1",
-                "extensionAttributes": [],
-                "code": "C70793",
-                "codeSystem": "http://www.cdisc.org",
-                "codeSystemVersion": "2024-09-27",
-                "decode": "Clinical Study Sponsor",
-                "instanceType": "Code"
-              },
-              "identifierScheme": "DUNS",
-              "identifier": "00-642-1325",
-              "legalAddress": {
-                "id": "Address_1",
-                "extensionAttributes": [],
-                "text": "Lilly Corporate Ctr, Indianapolis, , IN, 4628, United States of America",
-                "lines": [
-                  "Lilly Corporate Ctr"
-                ],
-                "city": "Indianapolis",
-                "district": "",
-                "state": "IN",
-                "postalCode": "4628",
-                "country": {
-                  "id": "Code_2",
-                  "extensionAttributes": [],
-                  "code": "USA",
-                  "codeSystem": "ISO 3166 1 alpha3",
-                  "codeSystemVersion": "2020-08",
-                  "decode": "United States of America",
-                  "instanceType": "Code"
-                },
-                "instanceType": "Address"
-              },
-              "managedSites": [],
-              "instanceType": "Organization"
-            },
             "instanceType": "StudyIdentifier"
           },
           {
@@ -305,47 +264,6 @@
             "extensionAttributes": [],
             "text": "NCT12345678",
             "scopeId": "Organization_2",
-            "scope":  {
-              "id": "Organization_2",
-              "extensionAttributes": [],
-              "name": "CT-GOV",
-              "label": "ClinicalTrials.gov",
-              "type": {
-                "id": "Code_3",
-                "extensionAttributes": [],
-                "code": "C93453",
-                "codeSystem": "http://www.cdisc.org",
-                "codeSystemVersion": "2024-09-27",
-                "decode": "Study Registry",
-                "instanceType": "Code"
-              },
-              "identifierScheme": "USGOV",
-              "identifier": "CT-GOV",
-              "legalAddress": {
-                "id": "Address_2",
-                "extensionAttributes": [],
-                "text": "National Library of Medicine, Bethesda, 8600 Rockville Pike, MD, 20894, United States of America",
-                "lines": [
-                  "National Library of Medicine"
-                ],
-                "city": "Bethesda",
-                "district": "8600 Rockville Pike",
-                "state": "MD",
-                "postalCode": "20894",
-                "country": {
-                  "id": "Code_4",
-                  "extensionAttributes": [],
-                  "code": "USA",
-                  "codeSystem": "ISO 3166 1 alpha3",
-                  "codeSystemVersion": "2020-08",
-                  "decode": "United States of America",
-                  "instanceType": "Code"
-                },
-                "instanceType": "Address"
-              },
-              "managedSites": [],
-              "instanceType": "Organization"
-            },
             "instanceType": "StudyIdentifier"
           }
         ],
@@ -17321,6 +17239,149 @@
             },
             "notes": [],
             "instanceType": "StudyRole"
+          }
+        ],
+         "organizations": [
+          {
+            "id": "Organization_1",
+            "extensionAttributes": [],
+            "name": "LILLY",
+            "label": "Eli Lilly",
+            "type": {
+              "id": "Code_1",
+              "extensionAttributes": [],
+              "code": "C70793",
+              "codeSystem": "http://www.cdisc.org",
+              "codeSystemVersion": "2024-09-27",
+              "decode": "Clinical Study Sponsor",
+              "instanceType": "Code"
+            },
+            "identifierScheme": "DUNS",
+            "identifier": "00-642-1325",
+            "legalAddress": {
+              "id": "Address_1",
+              "extensionAttributes": [],
+              "text": "Lilly Corporate Ctr, Indianapolis, , IN, 4628, United States of America",
+              "lines": [
+                "Lilly Corporate Ctr"
+              ],
+              "city": "Indianapolis",
+              "district": "",
+              "state": "IN",
+              "postalCode": "4628",
+              "country": {
+                "id": "Code_2",
+                "extensionAttributes": [],
+                "code": "USA",
+                "codeSystem": "ISO 3166 1 alpha3",
+                "codeSystemVersion": "2020-08",
+                "decode": "United States of America",
+                "instanceType": "Code"
+              },
+              "instanceType": "Address"
+            },
+            "managedSites": [],
+            "instanceType": "Organization"
+          },
+          {
+            "id": "Organization_2",
+            "extensionAttributes": [],
+            "name": "CT-GOV",
+            "label": "ClinicalTrials.gov",
+            "type": {
+              "id": "Code_3",
+              "extensionAttributes": [],
+              "code": "C93453",
+              "codeSystem": "http://www.cdisc.org",
+              "codeSystemVersion": "2024-09-27",
+              "decode": "Study Registry",
+              "instanceType": "Code"
+            },
+            "identifierScheme": "USGOV",
+            "identifier": "CT-GOV",
+            "legalAddress": {
+              "id": "Address_2",
+              "extensionAttributes": [],
+              "text": "National Library of Medicine, Bethesda, 8600 Rockville Pike, MD, 20894, United States of America",
+              "lines": [
+                "National Library of Medicine"
+              ],
+              "city": "Bethesda",
+              "district": "8600 Rockville Pike",
+              "state": "MD",
+              "postalCode": "20894",
+              "country": {
+                "id": "Code_4",
+                "extensionAttributes": [],
+                "code": "USA",
+                "codeSystem": "ISO 3166 1 alpha3",
+                "codeSystemVersion": "2020-08",
+                "decode": "United States of America",
+                "instanceType": "Code"
+              },
+              "instanceType": "Address"
+            },
+            "managedSites": [],
+            "instanceType": "Organization"
+          },
+          {
+            "id": "Organization_3",
+            "extensionAttributes": [],
+            "name": "SITE_ORG_1",
+            "label": "Big Hospital",
+            "type": {
+              "id": "Code_5",
+              "extensionAttributes": [],
+              "code": "C70793",
+              "codeSystem": "http://www.cdisc.org",
+              "codeSystemVersion": "2024-09-27",
+              "decode": "Clinical Study Sponsor",
+              "instanceType": "Code"
+            },
+            "identifierScheme": "DUNS",
+            "identifier": "123456789",
+            "legalAddress": {
+              "id": "Address_3",
+              "extensionAttributes": [],
+              "text": "line, city, district, state, postal_code, United Kingdom of Great Britain and Northern Ireland",
+              "lines": [
+                "line"
+              ],
+              "city": "city",
+              "district": "district",
+              "state": "state",
+              "postalCode": "postal_code",
+              "country": {
+                "id": "Code_6",
+                "extensionAttributes": [],
+                "code": "GBR",
+                "codeSystem": "ISO 3166 1 alpha3",
+                "codeSystemVersion": "2020-08",
+                "decode": "United Kingdom of Great Britain and Northern Ireland",
+                "instanceType": "Code"
+              },
+              "instanceType": "Address"
+            },
+            "managedSites": [
+              {
+                "id": "StudySite_1",
+                "extensionAttributes": [],
+                "name": "SITE_1",
+                "label": "Site One",
+                "description": "Main Site",
+                "country": {
+                  "id": "Code_669",
+                  "extensionAttributes": [],
+                  "code": "GBR",
+                  "codeSystem": "ISO 3166 1 alpha3",
+                  "codeSystemVersion": "2020-08",
+                  "decode": "United Kingdom of Great Britain and Northern Ireland",
+                  "instanceType": "Code"
+                },
+                "instanceType": "StudySite"
+              }
+            ],
+            "instanceType": "Organization"
           }
         ],
         "studyInterventions": [

--- a/src/TransCelerate.SDR.UnitTesting/GlobalTestSetup.cs
+++ b/src/TransCelerate.SDR.UnitTesting/GlobalTestSetup.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using NUnit.Framework;
+
+namespace TransCelerate.SDR.UnitTesting
+{
+    [SetUpFixture]
+    public class GlobalTestSetup
+    {
+        [OneTimeSetUp]
+        public void RunBeforeAnyTests()
+        {
+            ValidatorOptions.Global.DefaultRuleLevelCascadeMode = CascadeMode.Stop;
+        }
+    }
+}


### PR DESCRIPTION
Adding as a draft PR even though the work has barely been started, below are the notes on what needs to be done.

In the CDISC Pilot Data example json, the organisations data was stored under StudyVersions, and cross referenced in other places. This original data json format has been restored (reverting the change made in the V4.0.0 regression tests PR).

A lot of classes already have an Organization type property:

	• AssignedPerson
	• Identifier (and therefore it's inherited classes too)
		○ MedicalDeviceIdentifier
		○ ReferenceIdentifier
		○ StudyIdentifier
                ○ AdministrableProductIdentifier
	• ProductOrganizationRole
	• StudyRole

None of these have cross references implemented yet, even though according to the cross references diagram (https://github.com/cdisc-org/DDF-RA/blob/main/Documents/DDF%20USDM%20Model%20Informative.png) they all should be cross references.

It appears that StudyVersion is meant to hold the primary list of Organization data, this is consistent with the cross reference diagram and the CDISC Pilot data example. The Model UML and dataDictionary.md do not show this however, and it is not already implemented in the model, so it will need adding.

The work to do here therefore is as follows:

- [ ] Revert the StudyDataV5.json to its original state regarding organization data
- [ ] Add Organizations list property to StudyVersions model
- [ ] Identifier cross reference to Organization
- [ ] AssignedPerson cross reference to Organization
- [ ] ProductOrganizationRole cross reference to Organization
- [ ] StudyRole cross reference to Organization

Each cross reference will need:
- Model update
- Fix broken code and tests as a result of model update
- Validator update
- Reference integrity checks
- tests for reference integrity checks

We may be able to skip reference integrity checks if there is a rule definition which will be implemented in the CDISC rule engine.
