### PR TITLE
Model cross refs move master collections

### DIFF
--- a/src/TransCelerate.SDR.Core/DTO/StudyV5/StudyDesignDto.cs
+++ b/src/TransCelerate.SDR.Core/DTO/StudyV5/StudyDesignDto.cs
@@ -23,7 +23,6 @@ namespace TransCelerate.SDR.Core.DTO.StudyV5
         public string Rationale { get; set; }
         public List<BiomedicalConceptDto> BiomedicalConcepts { get; set; }
         public List<BiospecimenRetentionDto> BiospecimenRetentions { get; set; }
-        public List<BiomedicalConceptCategoryDto> BcCategories { get; set; }
         public List<StudyArmDto> Arms { get; set; }
         public List<StudyEpochDto> Epochs { get; set; }
         public List<StudyElementDto> Elements { get; set; }        

--- a/src/TransCelerate.SDR.Core/DTO/StudyV5/StudyDesignDto.cs
+++ b/src/TransCelerate.SDR.Core/DTO/StudyV5/StudyDesignDto.cs
@@ -30,7 +30,6 @@ namespace TransCelerate.SDR.Core.DTO.StudyV5
         public List<StudyElementDto> Elements { get; set; }        
         public List<StudyDefinitionDocumentVersionDto> DocumentVersions { get; set; }
         public List<SyntaxTemplateDictionaryDto> Dictionaries { get; set; }
-        public List<ConditionDto> Conditions { get; set; }
         public string InstanceType { get; set; }
         public List<CommentAnnotationDto> Notes { get; set; }
         public AliasCodeDto StudyPhase { get; set; }

--- a/src/TransCelerate.SDR.Core/DTO/StudyV5/StudyDesignDto.cs
+++ b/src/TransCelerate.SDR.Core/DTO/StudyV5/StudyDesignDto.cs
@@ -27,7 +27,6 @@ namespace TransCelerate.SDR.Core.DTO.StudyV5
         public List<StudyEpochDto> Epochs { get; set; }
         public List<StudyElementDto> Elements { get; set; }        
         public List<StudyDefinitionDocumentVersionDto> DocumentVersions { get; set; }
-        public List<SyntaxTemplateDictionaryDto> Dictionaries { get; set; }
         public string InstanceType { get; set; }
         public List<CommentAnnotationDto> Notes { get; set; }
         public AliasCodeDto StudyPhase { get; set; }

--- a/src/TransCelerate.SDR.Core/DTO/StudyV5/StudyDesignDto.cs
+++ b/src/TransCelerate.SDR.Core/DTO/StudyV5/StudyDesignDto.cs
@@ -24,7 +24,6 @@ namespace TransCelerate.SDR.Core.DTO.StudyV5
         public List<BiomedicalConceptDto> BiomedicalConcepts { get; set; }
         public List<BiospecimenRetentionDto> BiospecimenRetentions { get; set; }
         public List<BiomedicalConceptCategoryDto> BcCategories { get; set; }
-        public List<BiomedicalConceptSurrogateDto> BcSurrogates { get; set; }
         public List<StudyArmDto> Arms { get; set; }
         public List<StudyEpochDto> Epochs { get; set; }
         public List<StudyElementDto> Elements { get; set; }        

--- a/src/TransCelerate.SDR.Core/DTO/StudyV5/StudyVersionDto.cs
+++ b/src/TransCelerate.SDR.Core/DTO/StudyV5/StudyVersionDto.cs
@@ -18,5 +18,6 @@ namespace TransCelerate.SDR.Core.DTO.StudyV5
         public List<StudyDesignDto> StudyDesigns { get; set; }
         public List<StudyIdentifierDto> StudyIdentifiers { get; set; }
         public List<StudyTitleDto> Titles { get; set; }
+        public List<ConditionDto> Conditions { get; set; }
     }
 }

--- a/src/TransCelerate.SDR.Core/DTO/StudyV5/StudyVersionDto.cs
+++ b/src/TransCelerate.SDR.Core/DTO/StudyV5/StudyVersionDto.cs
@@ -19,5 +19,6 @@ namespace TransCelerate.SDR.Core.DTO.StudyV5
         public List<StudyIdentifierDto> StudyIdentifiers { get; set; }
         public List<StudyTitleDto> Titles { get; set; }
         public List<ConditionDto> Conditions { get; set; }
+        public List<BiomedicalConceptSurrogateDto> BcSurrogates { get; set; }
     }
 }

--- a/src/TransCelerate.SDR.Core/DTO/StudyV5/StudyVersionDto.cs
+++ b/src/TransCelerate.SDR.Core/DTO/StudyV5/StudyVersionDto.cs
@@ -20,5 +20,6 @@ namespace TransCelerate.SDR.Core.DTO.StudyV5
         public List<StudyTitleDto> Titles { get; set; }
         public List<ConditionDto> Conditions { get; set; }
         public List<BiomedicalConceptSurrogateDto> BcSurrogates { get; set; }
+        public List<BiomedicalConceptCategoryDto> BcCategories { get; set; }
     }
 }

--- a/src/TransCelerate.SDR.Core/DTO/StudyV5/StudyVersionDto.cs
+++ b/src/TransCelerate.SDR.Core/DTO/StudyV5/StudyVersionDto.cs
@@ -21,5 +21,6 @@ namespace TransCelerate.SDR.Core.DTO.StudyV5
         public List<ConditionDto> Conditions { get; set; }
         public List<BiomedicalConceptSurrogateDto> BcSurrogates { get; set; }
         public List<BiomedicalConceptCategoryDto> BcCategories { get; set; }
+        public List<SyntaxTemplateDictionaryDto> Dictionaries { get; set; }
     }
 }

--- a/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyDesignEntity.cs
+++ b/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyDesignEntity.cs
@@ -30,7 +30,6 @@ namespace TransCelerate.SDR.Core.Entities.StudyV5
         public List<StudyEpochEntity> Epochs { get; set; }
         public List<StudyElementEntity> Elements { get; set; }
         public List<StudyDefinitionDocumentVersionEntity> DocumentVersions { get; set; }
-        public List<SyntaxTemplateDictionaryEntity> Dictionaries { get; set; }
         public AliasCodeEntity StudyPhase { get; set; }
         public CodeEntity StudyType { get; set; }
         public List<CommentAnnotationEntity> Notes { get; set; }

--- a/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyDesignEntity.cs
+++ b/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyDesignEntity.cs
@@ -27,7 +27,6 @@ namespace TransCelerate.SDR.Core.Entities.StudyV5
         public List<BiomedicalConceptEntity> BiomedicalConcepts { get; set; }
         public List<BiospecimenRetentionEntity> BiospecimenRetentions { get; set; }
         public List<BiomedicalConceptCategoryEntity> BcCategories { get; set; }
-        public List<BiomedicalConceptSurrogateEntity> BcSurrogates { get; set; }
         public List<StudyArmEntity> Arms { get; set; }
         public List<StudyEpochEntity> Epochs { get; set; }
         public List<StudyElementEntity> Elements { get; set; }

--- a/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyDesignEntity.cs
+++ b/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyDesignEntity.cs
@@ -26,7 +26,6 @@ namespace TransCelerate.SDR.Core.Entities.StudyV5
         public string Rationale { get; set; }
         public List<BiomedicalConceptEntity> BiomedicalConcepts { get; set; }
         public List<BiospecimenRetentionEntity> BiospecimenRetentions { get; set; }
-        public List<BiomedicalConceptCategoryEntity> BcCategories { get; set; }
         public List<StudyArmEntity> Arms { get; set; }
         public List<StudyEpochEntity> Epochs { get; set; }
         public List<StudyElementEntity> Elements { get; set; }

--- a/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyDesignEntity.cs
+++ b/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyDesignEntity.cs
@@ -33,7 +33,6 @@ namespace TransCelerate.SDR.Core.Entities.StudyV5
         public List<StudyElementEntity> Elements { get; set; }
         public List<StudyDefinitionDocumentVersionEntity> DocumentVersions { get; set; }
         public List<SyntaxTemplateDictionaryEntity> Dictionaries { get; set; }
-        public List<ConditionEntity> Conditions { get; set; }
         public AliasCodeEntity StudyPhase { get; set; }
         public CodeEntity StudyType { get; set; }
         public List<CommentAnnotationEntity> Notes { get; set; }

--- a/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyVersionEntity.cs
+++ b/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyVersionEntity.cs
@@ -23,5 +23,6 @@ namespace TransCelerate.SDR.Core.Entities.StudyV5
         public List<ConditionEntity> Conditions { get; set; }
         public List<BiomedicalConceptSurrogateEntity> BcSurrogates { get; set; }
         public List<BiomedicalConceptCategoryEntity> BcCategories { get; set; }
+        public List<SyntaxTemplateDictionaryEntity> Dictionaries { get; set; }
     }
 }

--- a/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyVersionEntity.cs
+++ b/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyVersionEntity.cs
@@ -22,5 +22,6 @@ namespace TransCelerate.SDR.Core.Entities.StudyV5
         public List<StudyTitleEntity> Titles { get; set; }
         public List<ConditionEntity> Conditions { get; set; }
         public List<BiomedicalConceptSurrogateEntity> BcSurrogates { get; set; }
+        public List<BiomedicalConceptCategoryEntity> BcCategories { get; set; }
     }
 }

--- a/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyVersionEntity.cs
+++ b/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyVersionEntity.cs
@@ -21,5 +21,6 @@ namespace TransCelerate.SDR.Core.Entities.StudyV5
         public List<StudyIdentifierEntity> StudyIdentifiers { get; set; }
         public List<StudyTitleEntity> Titles { get; set; }
         public List<ConditionEntity> Conditions { get; set; }
+        public List<BiomedicalConceptSurrogateEntity> BcSurrogates { get; set; }
     }
 }

--- a/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyVersionEntity.cs
+++ b/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyVersionEntity.cs
@@ -20,5 +20,6 @@ namespace TransCelerate.SDR.Core.Entities.StudyV5
         public List<StudyDesignEntity> StudyDesigns { get; set; }
         public List<StudyIdentifierEntity> StudyIdentifiers { get; set; }
         public List<StudyTitleEntity> Titles { get; set; }
+        public List<ConditionEntity> Conditions { get; set; }
     }
 }

--- a/src/TransCelerate.SDR.Core/Utilities/Common/Constants.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Common/Constants.cs
@@ -381,7 +381,8 @@ namespace TransCelerate.SDR.Core.Utilities.Common
             nameof(Core.DTO.StudyV5.StudyVersionDto.Abbreviations),
             nameof(Core.DTO.StudyV5.StudyVersionDto.Notes),
             nameof(Core.DTO.StudyV5.StudyVersionDto.InstanceType),
-            nameof(Core.DTO.StudyV5.StudyVersionDto.Conditions)
+            nameof(Core.DTO.StudyV5.StudyVersionDto.Conditions),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.BcSurrogates),
 		};
 
         public static readonly string[] StudyDesignElementsV4 = {
@@ -438,7 +439,6 @@ namespace TransCelerate.SDR.Core.Utilities.Common
             nameof(Core.DTO.StudyV5.StudyDesignDto.Rationale),
             nameof(Core.DTO.StudyV5.StudyDesignDto.BiomedicalConcepts),
             nameof(Core.DTO.StudyV5.StudyDesignDto.BcCategories),
-            nameof(Core.DTO.StudyV5.StudyDesignDto.BcSurrogates),
             nameof(Core.DTO.StudyV5.StudyDesignDto.Dictionaries),
             nameof(Core.DTO.StudyV5.StudyDesignDto.Characteristics),
             nameof(Core.DTO.StudyV5.StudyDesignDto.InstanceType),

--- a/src/TransCelerate.SDR.Core/Utilities/Common/Constants.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Common/Constants.cs
@@ -383,6 +383,7 @@ namespace TransCelerate.SDR.Core.Utilities.Common
             nameof(Core.DTO.StudyV5.StudyVersionDto.InstanceType),
             nameof(Core.DTO.StudyV5.StudyVersionDto.Conditions),
             nameof(Core.DTO.StudyV5.StudyVersionDto.BcSurrogates),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.BcCategories)
 		};
 
         public static readonly string[] StudyDesignElementsV4 = {
@@ -438,7 +439,6 @@ namespace TransCelerate.SDR.Core.Utilities.Common
             nameof(Core.DTO.StudyV5.StudyDesignDto.Encounters),
             nameof(Core.DTO.StudyV5.StudyDesignDto.Rationale),
             nameof(Core.DTO.StudyV5.StudyDesignDto.BiomedicalConcepts),
-            nameof(Core.DTO.StudyV5.StudyDesignDto.BcCategories),
             nameof(Core.DTO.StudyV5.StudyDesignDto.Dictionaries),
             nameof(Core.DTO.StudyV5.StudyDesignDto.Characteristics),
             nameof(Core.DTO.StudyV5.StudyDesignDto.InstanceType),

--- a/src/TransCelerate.SDR.Core/Utilities/Common/Constants.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Common/Constants.cs
@@ -378,7 +378,6 @@ namespace TransCelerate.SDR.Core.Utilities.Common
 			nameof(Core.DTO.StudyV5.StudyVersionDto.Rationale),
 			nameof(Core.DTO.StudyV5.StudyVersionDto.Amendments),
 			nameof(Core.DTO.StudyV5.StudyVersionDto.DateValues),
-			nameof(Core.DTO.StudyV5.StudyVersionDto.NarrativeContentItems),
 			nameof(Core.DTO.StudyV5.StudyVersionDto.Abbreviations),
 			nameof(Core.DTO.StudyV5.StudyVersionDto.Notes),
 			nameof(Core.DTO.StudyV5.StudyVersionDto.InstanceType)

--- a/src/TransCelerate.SDR.Core/Utilities/Common/Constants.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Common/Constants.cs
@@ -383,7 +383,8 @@ namespace TransCelerate.SDR.Core.Utilities.Common
             nameof(Core.DTO.StudyV5.StudyVersionDto.InstanceType),
             nameof(Core.DTO.StudyV5.StudyVersionDto.Conditions),
             nameof(Core.DTO.StudyV5.StudyVersionDto.BcSurrogates),
-            nameof(Core.DTO.StudyV5.StudyVersionDto.BcCategories)
+            nameof(Core.DTO.StudyV5.StudyVersionDto.BcCategories),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.Dictionaries)
 		};
 
         public static readonly string[] StudyDesignElementsV4 = {
@@ -439,7 +440,6 @@ namespace TransCelerate.SDR.Core.Utilities.Common
             nameof(Core.DTO.StudyV5.StudyDesignDto.Encounters),
             nameof(Core.DTO.StudyV5.StudyDesignDto.Rationale),
             nameof(Core.DTO.StudyV5.StudyDesignDto.BiomedicalConcepts),
-            nameof(Core.DTO.StudyV5.StudyDesignDto.Dictionaries),
             nameof(Core.DTO.StudyV5.StudyDesignDto.Characteristics),
             nameof(Core.DTO.StudyV5.StudyDesignDto.InstanceType),
             nameof(Core.DTO.StudyV5.StudyDesignDto.StudyPhase),

--- a/src/TransCelerate.SDR.Core/Utilities/Common/Constants.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Common/Constants.cs
@@ -365,22 +365,23 @@ namespace TransCelerate.SDR.Core.Utilities.Common
             nameof(DTO.StudyV4.StudyVersionDto.InstanceType)
         };
 		public static readonly string[] StudyElementsV5 = {
-			nameof(Core.DTO.StudyV5.StudyDto.Name),
-			nameof(Core.DTO.StudyV5.StudyDto.Description),
-			nameof(Core.DTO.StudyV5.StudyDto.Label),
-			nameof(Core.DTO.StudyV5.StudyVersionDto.Titles),
-			nameof(Core.DTO.StudyV5.StudyVersionDto.StudyIdentifiers),
-			nameof(Core.DTO.StudyV5.StudyVersionDto.ReferenceIdentifiers),
-			nameof(Core.DTO.StudyV5.StudyVersionDto.DocumentVersionIds),
-			nameof(Core.DTO.StudyV5.StudyVersionDto.VersionIdentifier),
-			nameof(Core.DTO.StudyV5.StudyVersionDto.BusinessTherapeuticAreas),
-			nameof(Core.DTO.StudyV5.StudyVersionDto.StudyDesigns),
-			nameof(Core.DTO.StudyV5.StudyVersionDto.Rationale),
-			nameof(Core.DTO.StudyV5.StudyVersionDto.Amendments),
-			nameof(Core.DTO.StudyV5.StudyVersionDto.DateValues),
-			nameof(Core.DTO.StudyV5.StudyVersionDto.Abbreviations),
-			nameof(Core.DTO.StudyV5.StudyVersionDto.Notes),
-			nameof(Core.DTO.StudyV5.StudyVersionDto.InstanceType)
+            nameof(Core.DTO.StudyV5.StudyDto.Name),
+            nameof(Core.DTO.StudyV5.StudyDto.Description),
+            nameof(Core.DTO.StudyV5.StudyDto.Label),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.Titles),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.StudyIdentifiers),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.ReferenceIdentifiers),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.DocumentVersionIds),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.VersionIdentifier),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.BusinessTherapeuticAreas),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.StudyDesigns),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.Rationale),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.Amendments),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.DateValues),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.Abbreviations),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.Notes),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.InstanceType),
+            nameof(Core.DTO.StudyV5.StudyVersionDto.Conditions)
 		};
 
         public static readonly string[] StudyDesignElementsV4 = {
@@ -440,7 +441,6 @@ namespace TransCelerate.SDR.Core.Utilities.Common
             nameof(Core.DTO.StudyV5.StudyDesignDto.BcSurrogates),
             nameof(Core.DTO.StudyV5.StudyDesignDto.Dictionaries),
             nameof(Core.DTO.StudyV5.StudyDesignDto.Characteristics),
-            nameof(Core.DTO.StudyV5.StudyDesignDto.Conditions),
             nameof(Core.DTO.StudyV5.StudyDesignDto.InstanceType),
             nameof(Core.DTO.StudyV5.StudyDesignDto.StudyPhase),
 			nameof(Core.DTO.StudyV5.StudyDesignDto.StudyType)

--- a/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
@@ -2070,6 +2070,11 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                     {
                         changedValues.Add($"[{currentVersionIndex}].{x}");
                     });
+                    //Syntax Template Dictionaries
+                    GetDifferenceForAListForStudyComparison<SyntaxTemplateDictionaryEntity>(currVer.Dictionaries, prevVer.Dictionaries).ForEach(x =>
+                    {
+                        changedValues.Add($"{nameof(StudyVersionEntity.Dictionaries)}{x}");
+                    });
                 }
             });                                    
 
@@ -2414,11 +2419,6 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                         GetDifferenceForAListForStudyComparison<StudyElementEntity>(currentStudyDesign.Elements, previousStudyDesign.Elements).ForEach(x =>
                         {
                             changedValues.Add($"{nameof(StudyDesignEntity.Elements)}{x}");
-                        });
-                        //Syntax Template Dictionaries
-                        GetDifferenceForAListForStudyComparison<SyntaxTemplateDictionaryEntity>(currentStudyDesign.Dictionaries, previousStudyDesign.Dictionaries).ForEach(x =>
-                        {
-                            changedValues.Add($"{nameof(StudyDesignEntity.Dictionaries)}{x}");
                         });
                         //StudyPhase
                         GetDifferenceForAliasCodeForStudyComparison(currentStudyDesign.StudyPhase, previousStudyDesign.StudyPhase).ForEach(x =>

--- a/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
@@ -381,6 +381,11 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                     {
                         changedValues.Add($"{x}");
                     });
+                    //Conditions
+                    GetDifferenceForAList<ConditionEntity>(currVer.Conditions, prevVer.Conditions).ForEach(x =>
+                    {
+                        changedValues.Add($"{nameof(StudyVersionEntity.Conditions)}.{x}");
+                    });
                 }
             });
 
@@ -632,11 +637,6 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                         GetDifferenceForAList<StudyElementEntity>(currentStudyDesign.Elements, previousStudyDesign.Elements).ForEach(x =>
                         {
                             changedValues.Add($"{nameof(StudyDesignEntity.Elements)}.{x}");
-                        });
-                        //Conditions
-                        GetDifferenceForAList<ConditionEntity>(currentStudyDesign.Conditions, previousStudyDesign.Conditions).ForEach(x =>
-                        {
-                            changedValues.Add($"{nameof(StudyDesignEntity.Conditions)}.{x}");
                         });
                         //StudyPhase
                         GetDifferenceForAliasCode(currentStudyDesign.StudyPhase, previousStudyDesign.StudyPhase).ForEach(x =>
@@ -2057,6 +2057,11 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                     {
                         changedValues.Add($"[{currentVersionIndex}].{x}");
                     });
+                    //Conditions
+                    GetDifferenceForAListForStudyComparison<ConditionEntity>(currVer.Conditions, prevVer.Conditions).ForEach(x =>
+                    {
+                        changedValues.Add($"[{currentVersionIndex}].{x}");
+                    });
                 }
             });                                    
 
@@ -2417,11 +2422,6 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                         GetDifferenceForAListForStudyComparison<SyntaxTemplateDictionaryEntity>(currentStudyDesign.Dictionaries, previousStudyDesign.Dictionaries).ForEach(x =>
                         {
                             changedValues.Add($"{nameof(StudyDesignEntity.Dictionaries)}{x}");
-                        });
-                        //Conditions
-                        GetDifferenceForAListForStudyComparison<ConditionEntity>(currentStudyDesign.Conditions, previousStudyDesign.Conditions).ForEach(x =>
-                        {
-                            changedValues.Add($"{nameof(StudyDesignEntity.Conditions)}{x}");
                         });
                         //StudyPhase
                         GetDifferenceForAliasCodeForStudyComparison(currentStudyDesign.StudyPhase, previousStudyDesign.StudyPhase).ForEach(x =>

--- a/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
@@ -391,6 +391,11 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                     {
                         changedValues.Add($"{nameof(StudyVersionEntity.BcSurrogates)}.{x}");
                     });
+                    //Biomedical Concept Category
+                    GetDifferenceForAList<BiomedicalConceptCategoryEntity>(currVer.BcCategories, prevVer.BcCategories).ForEach(x =>
+                    {
+                        changedValues.Add($"{nameof(StudyVersionEntity.BcCategories)}.{x}");
+                    });
                 }
             });
 
@@ -612,12 +617,6 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
 
                         //Activities
                         changedValues.AddRange(GetDifferenceForActivities(currentStudyDesign, previousStudyDesign));
-
-                        //Biomedical Concept Category
-                        GetDifferenceForAList<BiomedicalConceptCategoryEntity>(currentStudyDesign.BcCategories, previousStudyDesign.BcCategories).ForEach(x =>
-                        {
-                            changedValues.Add($"{nameof(StudyDesignEntity.BcCategories)}.{x}");
-                        });
 
                         //Biomedical Concepts
                         changedValues.AddRange(GetDifferenceForBiomedicalConcepts(currentStudyDesign, previousStudyDesign));
@@ -2066,6 +2065,11 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                     {
                         changedValues.Add($"[{currentVersionIndex}].{x}");
                     });
+                    //Biomedical Concept Category
+                    GetDifferenceForAListForStudyComparison<BiomedicalConceptCategoryEntity>(currVer.BcCategories, prevVer.BcCategories).ForEach(x =>
+                    {
+                        changedValues.Add($"[{currentVersionIndex}].{x}");
+                    });
                 }
             });                                    
 
@@ -2392,11 +2396,6 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                         });
                         //Activities
                         changedValues.AddRange(GetDifferenceForActivitiesForStudyComparison(currentStudyDesign, previousStudyDesign));
-                        //Biomedical Concept Category
-                        GetDifferenceForAListForStudyComparison<BiomedicalConceptCategoryEntity>(currentStudyDesign.BcCategories, previousStudyDesign.BcCategories).ForEach(x =>
-                        {
-                            changedValues.Add($"{nameof(StudyDesignEntity.BcCategories)}{x}");
-                        });
 
                         //Biomedical Concepts
                         changedValues.AddRange(GetDifferenceForBiomedicalConceptsForStudyComparison(currentStudyDesign, previousStudyDesign));

--- a/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
@@ -143,6 +143,8 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                         jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyVersionDto.BcSurrogates).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                     else if (item == nameof(StudyVersionDto.BcCategories).ToLower())
                         jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyVersionDto.BcCategories).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
+                    else if (item == nameof(StudyVersionDto.Dictionaries).ToLower())
+                        jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyVersionDto.Dictionaries).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                     else if (item == nameof(StudyDto.Name).ToLower())
                         jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDto.Name).ChangeToCamelCase() && attr.Parent.Path == nameof(StudyDefinitionsDto.Study).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                     else if (item == nameof(StudyDto.Description).ToLower())
@@ -215,8 +217,6 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                                 jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDesignDto.Elements).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                             else if (item == nameof(StudyDesignDto.DocumentVersions).ToLower())
                                 jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDesignDto.DocumentVersions).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
-                            else if (item == nameof(StudyDesignDto.Dictionaries).ToLower())
-                                jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDesignDto.Dictionaries).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                             else if (item == nameof(StudyDesignDto.Characteristics).ToLower())
                                 jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDesignDto.Characteristics).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                             else if (item == nameof(StudyDesignDto.StudyPhase).ToLower())
@@ -1047,7 +1047,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                             () => errors.AddRange(ReferenceIntegrityValidationForStudyCells(design, designIndex, studyVersionIndex)),
 
                             //Eligibility Criteria
-                            () => errors.AddRange(ReferenceIntegrityValidationForEligibilityCriteriaAndCharacteristcs(design, designIndex, studyVersionIndex, studyVersionAndDesignIds)),
+                            () => errors.AddRange(ReferenceIntegrityValidationForEligibilityCriteriaAndCharacteristcs(studyVersion, design, designIndex, studyVersionIndex, studyVersionAndDesignIds)),
 
                             //Arms
                             () => errors.AddRange(ReferenceIntegrityValidationForStudyArms(design, designIndex, studyVersionIndex)),
@@ -1062,7 +1062,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                             () => errors.AddRange(ReferenceIntegrityValidationForProcedures(design, designIndex, studyVersionIndex)),
 
                             //Objectives & Endpoints
-                            () => errors.AddRange(ReferenceIntegrityValidationForObjectivesAndEndpoints(design, designIndex, studyVersionIndex))
+                            () => errors.AddRange(ReferenceIntegrityValidationForObjectivesAndEndpoints(studyVersion, design, designIndex, studyVersionIndex))
                         );
 
                     });
@@ -1275,13 +1275,13 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
             return errors;
         }
 
-        public static List<string> ReferenceIntegrityValidationForEligibilityCriteriaAndCharacteristcs(StudyDesignDto design, int indexOfDesign, int studyVersionIndex, List<string> studyVersionAndDesignIds)
+        public static List<string> ReferenceIntegrityValidationForEligibilityCriteriaAndCharacteristcs(StudyVersionDto version, StudyDesignDto design, int indexOfDesign, int studyVersionIndex, List<string> studyVersionAndDesignIds)
         {
             List<String> errors = new();
 
             if (design != null && design.Population != null)
             {
-                List<string> dictionaryIds = design.Dictionaries.Select(x => x.Id).ToList();
+                List<string> dictionaryIds = version.Dictionaries.Select(x => x.Id).ToList();
                // List<string> eligibilityCriteriaIds = design.Population.Criterionids != null ? design.Population.Criterionids.Select(act => act?.Id).ToList() : new();
                 design.Population.Criterionids?.ForEach(crit =>
                 {
@@ -1764,7 +1764,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
 
             if (version.Conditions != null && version.Conditions.Any())
             {
-                List<string> dictionaryIds = design.Dictionaries.Select(x => x.Id).ToList();
+                List<string> dictionaryIds = version.Dictionaries.Select(x => x.Id).ToList();
                 List<string> biomedicalConceptIds = design.BiomedicalConcepts is null ? new List<string>() : design.BiomedicalConcepts.Select(x => x.Id).ToList();
                 List<string> bcCategoryIds = version.BcCategories is null ? new List<string>() : version.BcCategories.Select(x => x.Id).ToList();
                 List<string> bcSurrogateIds = version.BcSurrogates is null ? new List<string>() : version.BcSurrogates.Select(x => x.Id).ToList();
@@ -1850,13 +1850,13 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
         }
 
 
-        public static List<string> ReferenceIntegrityValidationForObjectivesAndEndpoints(StudyDesignDto design, int indexOfDesign, int studyVersionIndex)
+        public static List<string> ReferenceIntegrityValidationForObjectivesAndEndpoints(StudyVersionDto version, StudyDesignDto design, int indexOfDesign, int studyVersionIndex)
         {
             List<String> errors = new();
 
             if (design.Objectives != null && design.Objectives.Any())
             {
-                List<string> dictionaryIds = design.Dictionaries.Select(x => x.Id).ToList();
+                List<string> dictionaryIds = version.Dictionaries.Select(x => x.Id).ToList();
 
                 design.Objectives.ForEach(objective =>
                 {

--- a/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
@@ -137,6 +137,8 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                         jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyVersionDto.DateValues).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                     else if (item == nameof(StudyVersionDto.Amendments).ToLower())
                         jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyVersionDto.Amendments).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
+                    else if (item == nameof(StudyVersionDto.Conditions).ToLower())
+                        jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyVersionDto.Conditions).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                     else if (item == nameof(StudyDto.Name).ToLower())
                         jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDto.Name).ChangeToCamelCase() && attr.Parent.Path == nameof(StudyDefinitionsDto.Study).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                     else if (item == nameof(StudyDto.Description).ToLower())
@@ -217,8 +219,6 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                                 jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDesignDto.Dictionaries).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                             else if (item == nameof(StudyDesignDto.Characteristics).ToLower())
                                 jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDesignDto.Characteristics).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
-                            else if (item == nameof(StudyDesignDto.Conditions).ToLower())
-                                jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDesignDto.Conditions).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                             else if (item == nameof(StudyDesignDto.StudyPhase).ToLower())
                                 jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDesignDto.StudyPhase).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                             else if (item == nameof(StudyDesignDto.StudyType).ToLower())
@@ -1013,6 +1013,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                     }
 
                     //Design elements
+                    var studyVersion = study.Study.Versions.FirstOrDefault();
                     var studyDesigns = study.Study.Versions.FirstOrDefault()?.StudyDesigns;
                     studyDesigns?.ForEach(design =>
                     {
@@ -1055,7 +1056,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                             () => errors.AddRange(ReferenceIntegrityValidationForStudyElements(design, designIndex, studyVersionIndex)),
 
                             //Conditions
-                            () => errors.AddRange(ReferenceIntegrityValidationForConditions(design, designIndex, studyVersionIndex)),
+                            () => errors.AddRange(ReferenceIntegrityValidationForConditions(studyVersion, design, designIndex, studyVersionIndex)),
 
                             //Procedures
                             () => errors.AddRange(ReferenceIntegrityValidationForProcedures(design, designIndex, studyVersionIndex)),
@@ -1757,11 +1758,11 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
             return errors;
         }
 
-        public static List<string> ReferenceIntegrityValidationForConditions(StudyDesignDto design, int indexOfDesign, int studyVersionIndex)
+        public static List<string> ReferenceIntegrityValidationForConditions(StudyVersionDto version, StudyDesignDto design, int indexOfDesign, int studyVersionIndex)
         {
             List<String> errors = new();
 
-            if (design.Conditions != null && design.Conditions.Any())
+            if (version.Conditions != null && version.Conditions.Any())
             {
                 List<string> dictionaryIds = design.Dictionaries.Select(x => x.Id).ToList();
                 List<string> biomedicalConceptIds = design.BiomedicalConcepts is null ? new List<string>() : design.BiomedicalConcepts.Select(x => x.Id).ToList();
@@ -1774,7 +1775,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                                                            .Select(z => z.Id)
                                                            .ToList() : new List<string>();
 
-                design.Conditions.ForEach(condition =>
+                version.Conditions.ForEach(condition =>
                 {
                     if (condition.DictionaryId !=null)
                     {
@@ -1782,7 +1783,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                             errors.Add($"{nameof(StudyDefinitionsDto.Study)}." +
                                 $"{nameof(StudyDto.Versions)}[{studyVersionIndex}]." +
                               $"{nameof(StudyVersionDto.StudyDesigns)}[{indexOfDesign}]." +
-                              $"{nameof(StudyDesignDto.Conditions)}[{design.Conditions.IndexOf(condition)}]." +
+                              $"{nameof(StudyVersionDto.Conditions)}[{version.Conditions.IndexOf(condition)}]." +
                               $"{nameof(ConditionDto.DictionaryId)}");
                     }
 
@@ -1799,7 +1800,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                                 errors.Add($"{nameof(StudyDefinitionsDto.Study)}." +
                                     $"{nameof(StudyDto.Versions)}[{studyVersionIndex}]." +
                                            $"{nameof(StudyVersionDto.StudyDesigns)}[{indexOfDesign}]." +
-                                           $"{nameof(StudyDesignDto.Conditions)}[{design.Conditions.IndexOf(condition)}]." +
+                                           $"{nameof(StudyVersionDto.Conditions)}[{version.Conditions.IndexOf(condition)}]." +
                                            $"{nameof(ConditionDto.AppliesToIds)}[{condition.AppliesToIds.IndexOf(appliesTo)}]");
                         });
                     }
@@ -1813,7 +1814,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                                 errors.Add($"{nameof(StudyDefinitionsDto.Study)}." +
                                     $"{nameof(StudyDto.Versions)}[{studyVersionIndex}]." +
                                            $"{nameof(StudyVersionDto.StudyDesigns)}[{indexOfDesign}]." +
-                                           $"{nameof(StudyDesignDto.Conditions)}[{design.Conditions.IndexOf(condition)}]." +
+                                           $"{nameof(StudyVersionDto.Conditions)}[{version.Conditions.IndexOf(condition)}]." +
                                            $"{nameof(ConditionDto.ContextIds)}[{condition.ContextIds.IndexOf(contextId)}]");
                         });
                     }                    

--- a/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
@@ -386,6 +386,11 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                     {
                         changedValues.Add($"{nameof(StudyVersionEntity.Conditions)}.{x}");
                     });
+                    //Biomedical Concept Surrogate
+                    GetDifferenceForAList<BiomedicalConceptSurrogateEntity>(currVer.BcSurrogates, prevVer.BcSurrogates).ForEach(x =>
+                    {
+                        changedValues.Add($"{nameof(StudyVersionEntity.BcSurrogates)}.{x}");
+                    });
                 }
             });
 
@@ -612,12 +617,6 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                         GetDifferenceForAList<BiomedicalConceptCategoryEntity>(currentStudyDesign.BcCategories, previousStudyDesign.BcCategories).ForEach(x =>
                         {
                             changedValues.Add($"{nameof(StudyDesignEntity.BcCategories)}.{x}");
-                        });
-
-                        //Biomedical Concept Surrogate
-                        GetDifferenceForAList<BiomedicalConceptSurrogateEntity>(currentStudyDesign.BcSurrogates, previousStudyDesign.BcSurrogates).ForEach(x =>
-                        {
-                            changedValues.Add($"{nameof(StudyDesignEntity.BcSurrogates)}.{x}");
                         });
 
                         //Biomedical Concepts
@@ -2062,6 +2061,11 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                     {
                         changedValues.Add($"[{currentVersionIndex}].{x}");
                     });
+                    //Biomedical Concept Surrogate
+                    GetDifferenceForAListForStudyComparison<BiomedicalConceptSurrogateEntity>(currVer.BcSurrogates, prevVer.BcSurrogates).ForEach(x =>
+                    {
+                        changedValues.Add($"[{currentVersionIndex}].{x}");
+                    });
                 }
             });                                    
 
@@ -2392,12 +2396,6 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                         GetDifferenceForAListForStudyComparison<BiomedicalConceptCategoryEntity>(currentStudyDesign.BcCategories, previousStudyDesign.BcCategories).ForEach(x =>
                         {
                             changedValues.Add($"{nameof(StudyDesignEntity.BcCategories)}{x}");
-                        });
-
-                        //Biomedical Concept Surrogate
-                        GetDifferenceForAListForStudyComparison<BiomedicalConceptSurrogateEntity>(currentStudyDesign.BcSurrogates, previousStudyDesign.BcSurrogates).ForEach(x =>
-                        {
-                            changedValues.Add($"{nameof(StudyDesignEntity.BcSurrogates)}{x}");
                         });
 
                         //Biomedical Concepts

--- a/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
@@ -64,7 +64,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                 {
                     foreach (string element in listofElementsArray)
                     {
-                        if (!Constants.StudyElementsV4.Select(x => x.ToLower()).Contains(element.ToLower()))
+                        if (!Constants.StudyElementsV5.Select(x => x.ToLower()).Contains(element.ToLower()))
                         {
                             isValid = false;
                             break;

--- a/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
@@ -141,7 +141,8 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                         jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyVersionDto.Conditions).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                     else if (item == nameof(StudyVersionDto.BcSurrogates).ToLower())
                         jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyVersionDto.BcSurrogates).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
-
+                    else if (item == nameof(StudyVersionDto.BcCategories).ToLower())
+                        jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyVersionDto.BcCategories).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                     else if (item == nameof(StudyDto.Name).ToLower())
                         jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDto.Name).ChangeToCamelCase() && attr.Parent.Path == nameof(StudyDefinitionsDto.Study).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                     else if (item == nameof(StudyDto.Description).ToLower())
@@ -206,8 +207,6 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                                 jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDesignDto.Rationale).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                             else if (item == nameof(StudyDesignDto.BiomedicalConcepts).ToLower())
                                 jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDesignDto.BiomedicalConcepts).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
-                            else if (item == nameof(StudyDesignDto.BcCategories).ToLower())
-                                jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDesignDto.BcCategories).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                             else if (item == nameof(StudyDesignDto.Arms).ToLower())
                                 jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDesignDto.Arms).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                             else if (item == nameof(StudyDesignDto.Epochs).ToLower())
@@ -1525,7 +1524,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
             if (design.Activities != null && design.Activities.Any())
             {
                 List<string> biomedicalConceptIds = design.BiomedicalConcepts is null ? new List<string>() : design.BiomedicalConcepts.Select(x => x.Id).ToList();
-                List<string> bcCategoryIds = design.BcCategories is null ? new List<string>() : design.BcCategories.Select(x => x.Id).ToList();
+                List<string> bcCategoryIds = version.BcCategories is null ? new List<string>() : version.BcCategories.Select(x => x.Id).ToList();
                 List<string> bcSurrogateIds = version.BcSurrogates is null ? new List<string>() : version.BcSurrogates.Select(x => x.Id).ToList();
                 List<string> activitiesIds = design.Activities.Select(act => act?.Id).ToList();
                 activitiesIds.RemoveAll(x => String.IsNullOrWhiteSpace(x));
@@ -1720,12 +1719,12 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
         {
             List<String> errors = new();
 
-            if (design.BcCategories != null && design.BcCategories.Any())
+            if (version.BcCategories != null && version.BcCategories.Any())
             {
                 List<string> biomedicalConceptIds = design.BiomedicalConcepts is null ? new List<string>() : design.BiomedicalConcepts.Select(x => x.Id).ToList();
-                List<string> bcCategoryIds = design.BcCategories is null ? new List<string>() : design.BcCategories.Select(x => x.Id).ToList();
+                List<string> bcCategoryIds = version.BcCategories is null ? new List<string>() : version.BcCategories.Select(x => x.Id).ToList();
                 List<string> bcSurrogateIds = version.BcSurrogates is null ? new List<string>() : version.BcSurrogates.Select(x => x.Id).ToList();
-                design.BcCategories.ForEach(bcCat =>
+                version.BcCategories.ForEach(bcCat =>
                 {
                     var tempCategoryIds = bcCategoryIds.ToList();
                     tempCategoryIds.RemoveAll(x => x == bcCat.Id);
@@ -1737,7 +1736,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                                 errors.Add($"{nameof(StudyDefinitionsDto.Study)}." +
                                     $"{nameof(StudyDto.Versions)}[{studyVersionIndex}]." +
                                            $"{nameof(StudyVersionDto.StudyDesigns)}[{indexOfDesign}]." +
-                                           $"{nameof(StudyDesignDto.BcCategories)}[{design.BcCategories.IndexOf(bcCat)}]." +
+                                           $"{nameof(StudyVersionDto.BcCategories)}[{version.BcCategories.IndexOf(bcCat)}]." +
                                            $"{nameof(BiomedicalConceptCategoryDto.ChildIds)}[{bcCat.ChildIds.IndexOf(child)}]");
                         });
                     }
@@ -1749,7 +1748,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                                 errors.Add($"{nameof(StudyDefinitionsDto.Study)}." +
                                     $"{nameof(StudyDto.Versions)}[{studyVersionIndex}]." +
                                            $"{nameof(StudyVersionDto.StudyDesigns)}[{indexOfDesign}]." +
-                                           $"{nameof(StudyDesignDto.BcCategories)}[{design.BcCategories.IndexOf(bcCat)}]." +
+                                           $"{nameof(StudyVersionDto.BcCategories)}[{version.BcCategories.IndexOf(bcCat)}]." +
                                            $"{nameof(BiomedicalConceptCategoryDto.MemberIds)}[{bcCat.MemberIds.IndexOf(member)}]");
                         });
                     }
@@ -1767,7 +1766,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
             {
                 List<string> dictionaryIds = design.Dictionaries.Select(x => x.Id).ToList();
                 List<string> biomedicalConceptIds = design.BiomedicalConcepts is null ? new List<string>() : design.BiomedicalConcepts.Select(x => x.Id).ToList();
-                List<string> bcCategoryIds = design.BcCategories is null ? new List<string>() : design.BcCategories.Select(x => x.Id).ToList();
+                List<string> bcCategoryIds = version.BcCategories is null ? new List<string>() : version.BcCategories.Select(x => x.Id).ToList();
                 List<string> bcSurrogateIds = version.BcSurrogates is null ? new List<string>() : version.BcSurrogates.Select(x => x.Id).ToList();
                 List<string> activitiesIds = design.Activities is null ? new List<string>() : design.Activities.Select(x => x.Id).ToList();
                 List<string> procedureIds = design.Activities is null ? new List<string>() : design.Activities.Where(x => x.DefinedProcedures is not null && x.DefinedProcedures.Any()).SelectMany(y => y.DefinedProcedures).Select(z=>z.Id).ToList();                

--- a/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Helpers/HelpersV5/HelperV5.cs
@@ -139,6 +139,9 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                         jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyVersionDto.Amendments).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                     else if (item == nameof(StudyVersionDto.Conditions).ToLower())
                         jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyVersionDto.Conditions).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
+                    else if (item == nameof(StudyVersionDto.BcSurrogates).ToLower())
+                        jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyVersionDto.BcSurrogates).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
+
                     else if (item == nameof(StudyDto.Name).ToLower())
                         jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDto.Name).ChangeToCamelCase() && attr.Parent.Path == nameof(StudyDefinitionsDto.Study).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                     else if (item == nameof(StudyDto.Description).ToLower())
@@ -205,8 +208,6 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                                 jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDesignDto.BiomedicalConcepts).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                             else if (item == nameof(StudyDesignDto.BcCategories).ToLower())
                                 jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDesignDto.BcCategories).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
-                            else if (item == nameof(StudyDesignDto.BcSurrogates).ToLower())
-                                jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDesignDto.BcSurrogates).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                             else if (item == nameof(StudyDesignDto.Arms).ToLower())
                                 jsonObject.Descendants().OfType<JProperty>().Where(attr => attr.Name == nameof(StudyDesignDto.Arms).ChangeToCamelCase()).ToList().ForEach(x => x.Remove());
                             else if (item == nameof(StudyDesignDto.Epochs).ToLower())
@@ -1032,7 +1033,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                             () => errors.AddRange(ReferenceIntegrityValidationForStudyScheduleTimelines(design, designIndex, studyVersionIndex)),
 
                             //Activities 
-                            () => errors.AddRange(ReferenceIntegrityValidationForActivities(design, designIndex, studyVersionIndex)),
+                            () => errors.AddRange(ReferenceIntegrityValidationForActivities(studyVersion, design, designIndex, studyVersionIndex)),
 
                             //Encounters
                             () => errors.AddRange(ReferenceIntegrityValidationForEncounters(design, designIndex, studyVersionIndex)),
@@ -1041,7 +1042,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                             () => errors.AddRange(ReferenceIntegrityValidationForStudyEstimands(design, designIndex, studyVersionIndex)),
 
                             //BcCategories
-                            () => errors.AddRange(ReferenceIntegrityValidationForBcCategories(design, designIndex, studyVersionIndex)),
+                            () => errors.AddRange(ReferenceIntegrityValidationForBcCategories(studyVersion, design, designIndex, studyVersionIndex)),
 
                             //BcCategories
                             () => errors.AddRange(ReferenceIntegrityValidationForStudyCells(design, designIndex, studyVersionIndex)),
@@ -1517,7 +1518,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
             return errors;
         }
 
-        public static List<string> ReferenceIntegrityValidationForActivities(StudyDesignDto design, int indexOfDesign, int studyVersionIndex)
+        public static List<string> ReferenceIntegrityValidationForActivities(StudyVersionDto version, StudyDesignDto design, int indexOfDesign, int studyVersionIndex)
         {
             List<String> errors = new();
 
@@ -1525,7 +1526,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
             {
                 List<string> biomedicalConceptIds = design.BiomedicalConcepts is null ? new List<string>() : design.BiomedicalConcepts.Select(x => x.Id).ToList();
                 List<string> bcCategoryIds = design.BcCategories is null ? new List<string>() : design.BcCategories.Select(x => x.Id).ToList();
-                List<string> bcSurrogateIds = design.BcSurrogates is null ? new List<string>() : design.BcSurrogates.Select(x => x.Id).ToList();
+                List<string> bcSurrogateIds = version.BcSurrogates is null ? new List<string>() : version.BcSurrogates.Select(x => x.Id).ToList();
                 List<string> activitiesIds = design.Activities.Select(act => act?.Id).ToList();
                 activitiesIds.RemoveAll(x => String.IsNullOrWhiteSpace(x));
                 List<string> scheduleTimelineIds = design.ScheduleTimelines is not null && design.ScheduleTimelines.Any() ? design.ScheduleTimelines.Select(x => x.Id).ToList() : new List<string>();
@@ -1715,7 +1716,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
             return errors;
         }
 
-        public static List<string> ReferenceIntegrityValidationForBcCategories(StudyDesignDto design, int indexOfDesign, int studyVersionIndex)
+        public static List<string> ReferenceIntegrityValidationForBcCategories(StudyVersionDto version, StudyDesignDto design, int indexOfDesign, int studyVersionIndex)
         {
             List<String> errors = new();
 
@@ -1723,7 +1724,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
             {
                 List<string> biomedicalConceptIds = design.BiomedicalConcepts is null ? new List<string>() : design.BiomedicalConcepts.Select(x => x.Id).ToList();
                 List<string> bcCategoryIds = design.BcCategories is null ? new List<string>() : design.BcCategories.Select(x => x.Id).ToList();
-                List<string> bcSurrogateIds = design.BcSurrogates is null ? new List<string>() : design.BcSurrogates.Select(x => x.Id).ToList();
+                List<string> bcSurrogateIds = version.BcSurrogates is null ? new List<string>() : version.BcSurrogates.Select(x => x.Id).ToList();
                 design.BcCategories.ForEach(bcCat =>
                 {
                     var tempCategoryIds = bcCategoryIds.ToList();
@@ -1767,7 +1768,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5
                 List<string> dictionaryIds = design.Dictionaries.Select(x => x.Id).ToList();
                 List<string> biomedicalConceptIds = design.BiomedicalConcepts is null ? new List<string>() : design.BiomedicalConcepts.Select(x => x.Id).ToList();
                 List<string> bcCategoryIds = design.BcCategories is null ? new List<string>() : design.BcCategories.Select(x => x.Id).ToList();
-                List<string> bcSurrogateIds = design.BcSurrogates is null ? new List<string>() : design.BcSurrogates.Select(x => x.Id).ToList();
+                List<string> bcSurrogateIds = version.BcSurrogates is null ? new List<string>() : version.BcSurrogates.Select(x => x.Id).ToList();
                 List<string> activitiesIds = design.Activities is null ? new List<string>() : design.Activities.Select(x => x.Id).ToList();
                 List<string> procedureIds = design.Activities is null ? new List<string>() : design.Activities.Where(x => x.DefinedProcedures is not null && x.DefinedProcedures.Any()).SelectMany(y => y.DefinedProcedures).Select(z=>z.Id).ToList();                
                 List<string> scheduleActivityInstanceIds = design.ScheduleTimelines is not null && design.ScheduleTimelines.Any() ? 

--- a/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/StudyDesignValidator.cs
+++ b/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/StudyDesignValidator.cs
@@ -189,16 +189,6 @@ namespace TransCelerate.SDR.RuleEngineV5
             RuleForEach(x => x.BiospecimenRetentions)
                 .SetValidator(new BiospecimenRetentionValidator(_httpContextAccessor));
 
-            RuleFor(x => x.BcCategories)
-                .Cascade(CascadeMode.Stop)
-                .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
-                .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
-                .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(StudyDesignValidator), nameof(StudyDesignDto.BcCategories)), ApplyConditionTo.AllValidators)
-                .Must(x => UniquenessArrayValidator.ValidateArrayV5(x)).WithMessage(Constants.ValidationErrorMessage.UniquenessArrayError);
-
-            RuleForEach(x => x.BcCategories)
-                .SetValidator(new BiomedicalConceptCategoryValidator(_httpContextAccessor));
-
             RuleFor(x => x.Arms)
                 .Cascade(CascadeMode.Stop)
                 .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)

--- a/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/StudyDesignValidator.cs
+++ b/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/StudyDesignValidator.cs
@@ -122,16 +122,6 @@ namespace TransCelerate.SDR.RuleEngineV5
             RuleForEach(x => x.TherapeuticAreas)
                 .SetValidator(new CodeValidator(_httpContextAccessor));
 
-            RuleFor(x => x.Conditions)
-               .Cascade(CascadeMode.Stop)
-               .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
-               .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
-               .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(StudyDesignValidator), nameof(StudyDesignDto.Conditions)), ApplyConditionTo.AllValidators)
-               .Must(x => UniquenessArrayValidator.ValidateArrayV5(x)).WithMessage(Constants.ValidationErrorMessage.UniquenessArrayError);
-
-            RuleForEach(x => x.Conditions)
-                .SetValidator(new ConditionValidator(_httpContextAccessor));
-
             RuleFor(x => x.Activities)
                 .Cascade(CascadeMode.Stop)
                 .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)

--- a/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/StudyDesignValidator.cs
+++ b/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/StudyDesignValidator.cs
@@ -219,16 +219,6 @@ namespace TransCelerate.SDR.RuleEngineV5
             RuleForEach(x => x.Elements)
                 .SetValidator(new StudyElementValidator(_httpContextAccessor));
 
-            RuleFor(x => x.Dictionaries)
-               .Cascade(CascadeMode.Stop)
-               .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
-               .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
-               .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(StudyDesignValidator), nameof(StudyDesignDto.Dictionaries)), ApplyConditionTo.AllValidators)
-               .Must(x => UniquenessArrayValidator.ValidateArrayV5(x)).WithMessage(Constants.ValidationErrorMessage.UniquenessArrayError);
-
-            RuleForEach(x => x.Dictionaries)
-                .SetValidator(new SyntaxTemplateDictionaryValidator(_httpContextAccessor));
-
             RuleFor(x => x.DocumentVersions)
                .Cascade(CascadeMode.Stop)
                .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)

--- a/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/StudyDesignValidator.cs
+++ b/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/StudyDesignValidator.cs
@@ -199,16 +199,6 @@ namespace TransCelerate.SDR.RuleEngineV5
             RuleForEach(x => x.BcCategories)
                 .SetValidator(new BiomedicalConceptCategoryValidator(_httpContextAccessor));
 
-            RuleFor(x => x.BcSurrogates)
-                .Cascade(CascadeMode.Stop)
-                .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)
-                .NotEmpty().WithMessage(Constants.ValidationErrorMessage.PropertyEmptyError)
-                .When(x => RulesHelper.GetConformanceRules(_httpContextAccessor.HttpContext.Request.Headers[IdFieldPropertyName.Common.UsdmVersion], nameof(StudyDesignValidator), nameof(StudyDesignDto.BcSurrogates)), ApplyConditionTo.AllValidators)
-                .Must(x => UniquenessArrayValidator.ValidateArrayV5(x)).WithMessage(Constants.ValidationErrorMessage.UniquenessArrayError);
-
-            RuleForEach(x => x.BcSurrogates)
-                .SetValidator(new BiomedicalConceptSurrogateValidator(_httpContextAccessor));
-
             RuleFor(x => x.Arms)
                 .Cascade(CascadeMode.Stop)
                 .NotNull().WithMessage(Constants.ValidationErrorMessage.PropertyMissingError)

--- a/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/StudyVersionValidator.cs
+++ b/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/StudyVersionValidator.cs
@@ -98,6 +98,10 @@ namespace TransCelerate.SDR.RuleEngine.StudyV5Rules
                 .NotNullOrEmptyIfRequired(nameof(StudyVersionDto.BcCategories), _requiredProperties)
                 .Must(x => UniquenessArrayValidator.ValidateArrayV5(x)).WithMessage(Constants.ValidationErrorMessage.UniquenessArrayError);
 
+            RuleFor(x => x.Dictionaries)
+               .NotNullOrEmptyIfRequired(nameof(StudyVersionDto.Dictionaries), _requiredProperties)
+               .Must(x => UniquenessArrayValidator.ValidateArrayV5(x)).WithMessage(Constants.ValidationErrorMessage.UniquenessArrayError);
+
             RuleFor(x => x.Abbreviations)
                 .Must(x => AbbreviationValidator.ValidateExpandedText(x))
                 .WithMessage(RuleConstants.RuleValidationWarningMessages.DDF00171)
@@ -136,9 +140,12 @@ namespace TransCelerate.SDR.RuleEngine.StudyV5Rules
 
             RuleForEach(x => x.BcSurrogates)
                 .SetValidator(new BiomedicalConceptSurrogateValidator(_httpContextAccessor));
-                
+
             RuleForEach(x => x.BcCategories)
                 .SetValidator(new BiomedicalConceptCategoryValidator(_httpContextAccessor));
+            
+            RuleForEach(x => x.Dictionaries)
+                .SetValidator(new SyntaxTemplateDictionaryValidator(_httpContextAccessor));
         }
     }
 }

--- a/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/StudyVersionValidator.cs
+++ b/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/StudyVersionValidator.cs
@@ -94,6 +94,10 @@ namespace TransCelerate.SDR.RuleEngine.StudyV5Rules
                 .NotNullOrEmptyIfRequired(nameof(StudyVersionDto.BcSurrogates), _requiredProperties)
                 .Must(x => UniquenessArrayValidator.ValidateArrayV5(x)).WithMessage(Constants.ValidationErrorMessage.UniquenessArrayError);
 
+            RuleFor(x => x.BcCategories)
+                .NotNullOrEmptyIfRequired(nameof(StudyVersionDto.BcCategories), _requiredProperties)
+                .Must(x => UniquenessArrayValidator.ValidateArrayV5(x)).WithMessage(Constants.ValidationErrorMessage.UniquenessArrayError);
+
             RuleFor(x => x.Abbreviations)
                 .Must(x => AbbreviationValidator.ValidateExpandedText(x))
                 .WithMessage(RuleConstants.RuleValidationWarningMessages.DDF00171)
@@ -126,12 +130,15 @@ namespace TransCelerate.SDR.RuleEngine.StudyV5Rules
 
             RuleForEach(x => x.Titles)
                 .SetValidator(new StudyTitleValidator(_httpContextAccessor));
-            
+
             RuleForEach(x => x.Conditions)
                 .SetValidator(new ConditionValidator(_httpContextAccessor));
 
             RuleForEach(x => x.BcSurrogates)
                 .SetValidator(new BiomedicalConceptSurrogateValidator(_httpContextAccessor));
+                
+            RuleForEach(x => x.BcCategories)
+                .SetValidator(new BiomedicalConceptCategoryValidator(_httpContextAccessor));
         }
     }
 }

--- a/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/StudyVersionValidator.cs
+++ b/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/StudyVersionValidator.cs
@@ -86,6 +86,10 @@ namespace TransCelerate.SDR.RuleEngine.StudyV5Rules
                 .Must(x => UniquenessArrayValidator.ValidateArrayV5(x)).WithMessage(Constants.ValidationErrorMessage.UniquenessArrayError)
                 .Must(x => x.Where(y => y.Type != null).Select(y => y.Type.Decode == Constants.StudyTitle.OfficialStudyTitle).Count() > 0).WithMessage(Constants.ValidationErrorMessage.OfficialTitleError);
 
+            RuleFor(x => x.Conditions)
+               .NotNullOrEmptyIfRequired(nameof(StudyVersionDto.Conditions), _requiredProperties)
+               .Must(x => UniquenessArrayValidator.ValidateArrayV5(x)).WithMessage(Constants.ValidationErrorMessage.UniquenessArrayError);
+
             RuleFor(x => x.Abbreviations)
                 .Must(x => AbbreviationValidator.ValidateExpandedText(x))
                 .WithMessage(RuleConstants.RuleValidationWarningMessages.DDF00171)
@@ -118,6 +122,9 @@ namespace TransCelerate.SDR.RuleEngine.StudyV5Rules
 
             RuleForEach(x => x.Titles)
                 .SetValidator(new StudyTitleValidator(_httpContextAccessor));
+            
+            RuleForEach(x => x.Conditions)
+                .SetValidator(new ConditionValidator(_httpContextAccessor));
         }
     }
 }

--- a/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/StudyVersionValidator.cs
+++ b/src/TransCelerate.SDR.RuleEngine/StudyV5Rules/StudyVersionValidator.cs
@@ -90,6 +90,10 @@ namespace TransCelerate.SDR.RuleEngine.StudyV5Rules
                .NotNullOrEmptyIfRequired(nameof(StudyVersionDto.Conditions), _requiredProperties)
                .Must(x => UniquenessArrayValidator.ValidateArrayV5(x)).WithMessage(Constants.ValidationErrorMessage.UniquenessArrayError);
 
+            RuleFor(x => x.BcSurrogates)
+                .NotNullOrEmptyIfRequired(nameof(StudyVersionDto.BcSurrogates), _requiredProperties)
+                .Must(x => UniquenessArrayValidator.ValidateArrayV5(x)).WithMessage(Constants.ValidationErrorMessage.UniquenessArrayError);
+
             RuleFor(x => x.Abbreviations)
                 .Must(x => AbbreviationValidator.ValidateExpandedText(x))
                 .WithMessage(RuleConstants.RuleValidationWarningMessages.DDF00171)
@@ -125,6 +129,9 @@ namespace TransCelerate.SDR.RuleEngine.StudyV5Rules
             
             RuleForEach(x => x.Conditions)
                 .SetValidator(new ConditionValidator(_httpContextAccessor));
+
+            RuleForEach(x => x.BcSurrogates)
+                .SetValidator(new BiomedicalConceptSurrogateValidator(_httpContextAccessor));
         }
     }
 }

--- a/src/TransCelerate.SDR.Service/Services/StudyServiceV5.cs
+++ b/src/TransCelerate.SDR.Service/Services/StudyServiceV5.cs
@@ -268,10 +268,10 @@ namespace TransCelerate.SDR.Services.Services
                     if (checkStudy == null)
                         return Constants.ErrorMessages.Forbidden;
 
-                    var studyVersions = study.Study.Versions?.FirstOrDefault();
-                    var soa = SoAV5(studyVersions?.StudyDesigns);
+                    var studyVersion = study.Study.Versions?.FirstOrDefault();
+                    var soa = SoAV5(studyVersion);
                     soa.StudyId = study.Study.Id;
-                    soa.StudyTitle = studyVersions != null ? studyVersions.Titles.GetStudyTitleV5(Constants.StudyTitle.OfficialStudyTitle) : null;
+                    soa.StudyTitle = studyVersion != null ? studyVersion.Titles.GetStudyTitleV5(Constants.StudyTitle.OfficialStudyTitle) : null;
                     if (!String.IsNullOrWhiteSpace(studyDesignId))
                     {
                         if (study.Study.Versions != null && study.Study.Versions.FirstOrDefault()?.StudyDesigns is null || !soa.StudyDesigns.Any(x => x.StudyDesignId == studyDesignId))
@@ -301,8 +301,9 @@ namespace TransCelerate.SDR.Services.Services
             }
         }
 
-        public SoADto SoAV5(List<StudyDesignEntity> studyDesigns)
+        public SoADto SoAV5(StudyVersionEntity version)
         {
+            var studyDesigns = version?.StudyDesigns;
             SoADto soADto = new()
             {
                 StudyDesigns = new List<StudyDesigns>()
@@ -332,7 +333,7 @@ namespace TransCelerate.SDR.Services.Services
 
                             var scheduleActivityInstances = scheduleTimeline.Instances?.Select(x => (x as ScheduledActivityInstanceEntity))
                                                                          .Where(x => x != null).ToList();
-                            var conditions = design.Conditions is not null ? design.Conditions : new List<ConditionEntity>();
+                            var conditions = version.Conditions is not null ? version.Conditions : new List<ConditionEntity>();
                             
                             if (scheduleActivityInstances != null && scheduleActivityInstances.Any())
                             {

--- a/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/HelperV2ClassesUnitTesting.cs
+++ b/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/HelperV2ClassesUnitTesting.cs
@@ -68,7 +68,11 @@ namespace TransCelerate.SDR.UnitTesting
         public void ApiBehaviourOptionsHelper()
         {
             ApiBehaviourOptionsHelper apiBehaviourOptionsHelper = new(_mockLogger);
-            ActionContext context = new();
+            ActionContext context = new()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
             var studyDto = GetDtoDataFromStaticJson();
             studyDto.Study = null;
             var httpContextAccessor = new Mock<IHttpContextAccessor>();
@@ -77,7 +81,6 @@ namespace TransCelerate.SDR.UnitTesting
             contextAccessor.Request.Headers["usdmVersion"] = usdmVersion;
             httpContextAccessor.Setup(_ => _.HttpContext).Returns(contextAccessor);
 
-
             StudyDefinitionsValidator studyDefinitionsValidator = new(httpContextAccessor.Object);
             var errors = studyDefinitionsValidator.Validate(studyDto).Errors;
             context.ModelState.AddModelError("study", errors[0].ErrorMessage);
@@ -85,7 +88,10 @@ namespace TransCelerate.SDR.UnitTesting
             Assert.IsInstanceOf(typeof(BadRequestObjectResult), response);
 
 
-            context.ModelState.Clear();
+            context = new()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
             studyDto = GetDtoDataFromStaticJson();
             studyDto.Study.StudyTitle = null;
 

--- a/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/HelperV3ClassesUnitTesting.cs
+++ b/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/HelperV3ClassesUnitTesting.cs
@@ -68,7 +68,11 @@ namespace TransCelerate.SDR.UnitTesting
         public void ApiBehaviourOptionsHelper()
         {
             ApiBehaviourOptionsHelper apiBehaviourOptionsHelper = new(_mockLogger);
-            ActionContext context = new();
+            ActionContext context = new()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
             var studyDto = GetDtoDataFromStaticJson();
             studyDto.Study = null;
             var httpContextAccessor = new Mock<IHttpContextAccessor>();
@@ -85,7 +89,10 @@ namespace TransCelerate.SDR.UnitTesting
             Assert.IsInstanceOf(typeof(BadRequestObjectResult), response);
 
 
-            context.ModelState.Clear();
+            context = new()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
             studyDto = GetDtoDataFromStaticJson();
             studyDto.Study.StudyTitle = null;
 

--- a/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/HelperV4ClassesUnitTesting.cs
+++ b/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/HelperV4ClassesUnitTesting.cs
@@ -63,7 +63,11 @@ namespace TransCelerate.SDR.UnitTesting
         public void ApiBehaviourOptionsHelper()
         {
             ApiBehaviourOptionsHelper apiBehaviourOptionsHelper = new(_mockLogger);
-            ActionContext context = new();
+            ActionContext context = new()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
             var studyDto = GetDtoDataFromStaticJson();
             studyDto.Study = null;
             var httpContextAccessor = new Mock<IHttpContextAccessor>();
@@ -80,7 +84,10 @@ namespace TransCelerate.SDR.UnitTesting
             Assert.IsInstanceOf(typeof(BadRequestObjectResult), response);
 
 
-            context.ModelState.Clear();
+            context = new()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
             studyDto = GetDtoDataFromStaticJson();
             studyDto.Study.Versions.FirstOrDefault().Titles = null;
 

--- a/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/HelperV5ClassesUnitTesting.cs
+++ b/src/TransCelerate.SDR.UnitTesting/CommonClassesUnitTesting/HelperV5ClassesUnitTesting.cs
@@ -17,6 +17,8 @@ using TransCelerate.SDR.Core.Utilities.Common;
 using TransCelerate.SDR.Core.Utilities.Helpers;
 using TransCelerate.SDR.Core.Utilities.Helpers.HelpersV5;
 using TransCelerate.SDR.DataAccess.Filters;
+using TransCelerate.SDR.RuleEngine.Common;
+using TransCelerate.SDR.RuleEngine.StudyV5Rules;
 using TransCelerate.SDR.RuleEngineV5;
 
 namespace TransCelerate.SDR.UnitTesting
@@ -62,7 +64,11 @@ namespace TransCelerate.SDR.UnitTesting
         public void ApiBehaviourOptionsHelper()
         {
             ApiBehaviourOptionsHelper apiBehaviourOptionsHelper = new(_mockLogger);
-            ActionContext context = new();
+            ActionContext context = new()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
             var studyDto = GetDtoDataFromStaticJson();
             studyDto.Study = null;
             var httpContextAccessor = new Mock<IHttpContextAccessor>();
@@ -71,7 +77,6 @@ namespace TransCelerate.SDR.UnitTesting
             contextAccessor.Request.Headers["usdmVersion"] = usdmVersion;
             httpContextAccessor.Setup(_ => _.HttpContext).Returns(contextAccessor);
 
-
             StudyDefinitionsValidator studyDefinitionsValidator = new(httpContextAccessor.Object);
             var errors = studyDefinitionsValidator.Validate(studyDto).Errors;
             context.ModelState.AddModelError("study", errors[0].ErrorMessage);
@@ -79,7 +84,10 @@ namespace TransCelerate.SDR.UnitTesting
             Assert.IsInstanceOf(typeof(BadRequestObjectResult), response);
 
 
-            context.ModelState.Clear();
+            context = new()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
             studyDto = GetDtoDataFromStaticJson();
             studyDto.Study.Versions.FirstOrDefault().Titles = null;
 

--- a/src/TransCelerate.SDR.UnitTesting/GlobalTestSetup.cs
+++ b/src/TransCelerate.SDR.UnitTesting/GlobalTestSetup.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using NUnit.Framework;
+
+namespace TransCelerate.SDR.UnitTesting
+{
+    [SetUpFixture]
+    public class GlobalTestSetup
+    {
+        [OneTimeSetUp]
+        public void RunBeforeAnyTests()
+        {
+            ValidatorOptions.Global.DefaultRuleLevelCascadeMode = CascadeMode.Stop;
+        }
+    }
+}


### PR DESCRIPTION
Some of the existing master copies of collections were incorrectly stored on the StudyDesign objects, when the cross references diagram shows that they should be on the StudyVersion object. Also, in the CDISC Pilot example json, these collections are on the StudyVersion, not the StudyDesign. 

This PR moves these collections from StudyDesign dto/entity to StudyVersion dto/entity where they should be