### PR TITLE
Custom Built CDISC Rules Engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ FROM ubuntu:24.04 AS runtime
 ENV DEBIAN_FRONTEND=noninteractive \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 \
     ASPNETCORE_URLS=http://+:80 \
+    CdiscRulesEngine_LATEST_RELEASE_URL=https://api.github.com/repos/cdisc-org/cdisc-rules-engine/releases/latest \
+    CdiscRulesEngine_LATEST_RELEASE_ZIP=core-ubuntu-latest.zip \
     CdiscRulesEngine=/app/cdisc-rules-engine \
     CdiscRulesEngineRelativeBinary=core \
     CdiscRulesEngineRelativeCache=resources/cache
@@ -47,7 +49,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Download CDISC Rules Engine
-RUN LATEST_RELEASE_URL=$(curl -s --fail --retry 3 https://api.github.com/repos/cdisc-org/cdisc-rules-engine/releases/latest | jq -r '.assets[] | select(.name == "core-ubuntu-latest.zip") | .browser_download_url') \
+RUN LATEST_RELEASE_URL=$(curl -s --fail --retry 3 $CdiscRulesEngine_LATEST_RELEASE_URL | jq -r --arg zip_name "$CdiscRulesEngine_LATEST_RELEASE_ZIP" '.assets[] | select(.name == $zip_name) | .browser_download_url') \
     && echo "Downloading from: $LATEST_RELEASE_URL" \
     && curl -L \
         --fail \


### PR DESCRIPTION
This PR allows us to use our temporary custom built binary before CDISC releases the updated binary with performance enhancements