### PR TITLE
1210 study search error usdm4

### DIFF
--- a/src/TransCelerate.SDR.DataAccess/Repositories/CommonRepository.cs
+++ b/src/TransCelerate.SDR.DataAccess/Repositories/CommonRepository.cs
@@ -544,13 +544,13 @@ namespace TransCelerate.SDR.DataAccess.Repositories
                                                   StudyId = x.Study.Id,
                                                   StudyTitle = x.Study.Versions != null ? x.Study.Versions.First().Titles : null,
                                                   StudyType = x.Study.Versions != null && x.Study.Versions.Any()
-                                                                    && x.Study.Versions.First().StudyDesigns != null
-                                                                    && x.Study.Versions.First().StudyDesigns.Any()
-                                                                    ? x.Study.Versions.First().StudyDesigns.First().StudyType : null,
-                                                  StudyPhase = x.Study.Versions != null && x.Study.Versions.Any()
-                                                                    && x.Study.Versions.First().StudyDesigns != null
-                                                                    && x.Study.Versions.First().StudyDesigns.Any()
-                                                                    ? x.Study.Versions.First().StudyDesigns.First().StudyPhase : null,
+                                                                && x.Study.Versions.First().StudyDesigns != null
+                                                                && x.Study.Versions.First().StudyDesigns.Any()
+                                                                ? x.Study.Versions.First().StudyDesigns.ElementAt(0).StudyType : null,
+                                              StudyPhase = x.Study.Versions != null && x.Study.Versions.Any()
+                                                                && x.Study.Versions.First().StudyDesigns != null
+                                                                && x.Study.Versions.First().StudyDesigns.Any()
+                                                                ? x.Study.Versions.First().StudyDesigns.ElementAt(0).StudyPhase : null,
                                                   StudyIdentifiers = x.Study.Versions != null ? x.Study.Versions.First().StudyIdentifiers : null,
                                                   StudyIndications = x.Study.Versions != null ? x.Study.Versions.Select(y => y.StudyDesigns.Select(x => x.Indications)) : null,
                                                   EntryDateTime = x.AuditTrail.EntryDateTime,


### PR DESCRIPTION
Fixes the error when searching for USDM 4.0 studies. The mongodb LINQ query projection seemed to be struggling with the chained `.First()....First()` calls within the projection, and replacing the latter `.First()` with `.ElementAt[0]` has fixed it.

It is now returning a 404 error saying 'no results', which I think is expected as no valid usdm 4.0 studies have been successfully inserted into the db yet. I tested this using a locally running API connected to a locally running mongodb.

I will work on adding a 4.0 study so that I can confirm that it appears in the search results.