### PR TITLE
Search sponsor id fix

### DIFF
--- a/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyDesignPopulationEntity.cs
+++ b/src/TransCelerate.SDR.Core/Entities/StudyV5/StudyDesignPopulationEntity.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections.Generic;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace TransCelerate.SDR.Core.Entities.StudyV5
 {
-    [MongoDB.Bson.Serialization.Attributes.BsonNoId]
+    [BsonNoId]
+    [BsonIgnoreExtraElements]
     public class StudyDesignPopulationEntity : PopulationDefinitionEntity
     {
         public List<StudyCohortEntity> Cohorts { get; set; }

--- a/src/TransCelerate.SDR.DataAccess/Filters/DataFilterCommon.cs
+++ b/src/TransCelerate.SDR.DataAccess/Filters/DataFilterCommon.cs
@@ -679,7 +679,12 @@ namespace TransCelerate.SDR.DataAccess.Filters
                 filter &= builder.Where(x =>
                     x.Study.Versions[0].Organizations.Any(org =>
                         org.Identifier.ToLower().Contains(searchParameters.SponsorId.ToLower()) &&
-                        org.Type.Decode.ToLower() == Constants.IdType.SPONSOR_ID_V1.ToLower()));
+                        (
+                            org.Type.Decode.ToLower() == Constants.IdType.SPONSOR_ID_V1.ToLower() ||
+                            org.Type.Decode.ToLower() == Constants.IdType.SPONSOR_ID_V2.ToLower()
+                        )
+                    )
+                );
             }
 
             //Filter for Indication
@@ -741,7 +746,11 @@ namespace TransCelerate.SDR.DataAccess.Filters
 
             var sponsorIdentifier = searchResponse.StudyIdentifiers
                 .FirstOrDefault(x => scopeLookup.ContainsKey(x.ScopeId) &&
-                                    scopeLookup[x.ScopeId]?.Type?.Decode?.ToLower() == Constants.IdType.SPONSOR_ID_V1.ToLower());
+                    (
+                        scopeLookup[x.ScopeId]?.Type?.Decode?.ToLower() == Constants.IdType.SPONSOR_ID_V1.ToLower() ||
+                        scopeLookup[x.ScopeId]?.Type?.Decode?.ToLower() == Constants.IdType.SPONSOR_ID_V2.ToLower()
+                    )
+                );
 
             return sponsorIdentifier != null && scopeLookup.ContainsKey(sponsorIdentifier.ScopeId)
                 ? scopeLookup[sponsorIdentifier.ScopeId]?.Identifier ?? ""

--- a/src/TransCelerate.SDR.DataAccess/Filters/DataFilterCommon.cs
+++ b/src/TransCelerate.SDR.DataAccess/Filters/DataFilterCommon.cs
@@ -7,7 +7,6 @@ using System.Text.RegularExpressions;
 using TransCelerate.SDR.Core.Entities.Common;
 using TransCelerate.SDR.Core.Utilities;
 using TransCelerate.SDR.Core.Utilities.Common;
-using TransCelerate.SDR.Core.Utilities.Helpers;
 
 namespace TransCelerate.SDR.DataAccess.Filters
 {
@@ -680,9 +679,7 @@ namespace TransCelerate.SDR.DataAccess.Filters
                 filter &= builder.Where(x =>
                     x.Study.Versions[0].Organizations.Any(org =>
                         org.Identifier.ToLower().Contains(searchParameters.SponsorId.ToLower()) &&
-                        CodeValueHelper.IsSponsorDecode(org.Type.Decode)
-                    )
-                );
+                        org.Type.Decode.ToLower() == Constants.IdType.SPONSOR_ID_V1.ToLower()));
             }
 
             //Filter for Indication
@@ -744,7 +741,7 @@ namespace TransCelerate.SDR.DataAccess.Filters
 
             var sponsorIdentifier = searchResponse.StudyIdentifiers
                 .FirstOrDefault(x => scopeLookup.ContainsKey(x.ScopeId) &&
-                        CodeValueHelper.IsSponsorDecode(scopeLookup[x.ScopeId]?.Type?.Decode));
+                                    scopeLookup[x.ScopeId]?.Type?.Decode?.ToLower() == Constants.IdType.SPONSOR_ID_V1.ToLower());
 
             return sponsorIdentifier != null && scopeLookup.ContainsKey(sponsorIdentifier.ScopeId)
                 ? scopeLookup[sponsorIdentifier.ScopeId]?.Identifier ?? ""


### PR DESCRIPTION
Fix the V5 search endpoint, where the mongodb query can only handle a subset of valid C# code.

Endpoint is now working locally:

<img width="1405" height="1991" alt="image" src="https://github.com/user-attachments/assets/43803e37-c432-490d-8a81-3291d5e70179" />
