### PR TITLE
eCPT age min and max bug fix

### DIFF
--- a/src/TransCelerate.SDR.Core/Utilities/Helpers/eCPTHelper.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Helpers/eCPTHelper.cs
@@ -297,10 +297,10 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers
         {
             if (population?.PlannedEnrollmentNumber is Core.DTO.StudyV5.RangeDto plannedEnrollmentNumberRange)
             {
-                if (Convert.ToInt32(plannedEnrollmentNumberRange.MaxValue) == Convert.ToInt32(plannedEnrollmentNumberRange.MinValue))
-                    return plannedEnrollmentNumberRange.MaxValue.ToString();
+                if (Convert.ToInt32(plannedEnrollmentNumberRange.MaxValue.Value) == Convert.ToInt32(plannedEnrollmentNumberRange.MinValue.Value))
+                    return plannedEnrollmentNumberRange.MaxValue.Value.ToString();
                 else
-                    return $"{plannedEnrollmentNumberRange.MinValue} to {plannedEnrollmentNumberRange.MaxValue}";
+                    return $"{plannedEnrollmentNumberRange.MinValue.Value} to {plannedEnrollmentNumberRange.MaxValue.Value}";
             }
             else if (population?.PlannedEnrollmentNumber is Core.DTO.StudyV5.QuantityDto plannedEnrollmentNumberQuantity)
             {
@@ -352,7 +352,7 @@ namespace TransCelerate.SDR.Core.Utilities.Helpers
                 {
                     plannedAges.AddRange(population.Cohorts.Where(x => x.PlannedAge is not null).Select(x => x.PlannedAge).ToList());
                 }
-                return isMax ? plannedAges.Max(x => x.MaxValue).ToString() : plannedAges.Min(x => x.MinValue).ToString();
+                return isMax ? plannedAges.Max(x => x.MaxValue.Value).ToString() : plannedAges.Min(x => x.MinValue.Value).ToString();
             }
             return null;
         }


### PR DESCRIPTION
The min and max age of subjects property of the V5 eCPT endpoint was showing a string of the class type, rather than an actual value. This was because the plannedEnrollmentNumberRange is now a range object, and the the value is nested inside the `.Value` property.

The eCPT endpoint is now returning correct values here:

<img width="745" height="309" alt="image" src="https://github.com/user-attachments/assets/8726af0f-c559-4872-92f7-57c19ecbf43d" />

The numberOfParticipants property was also fixed in the case where plannedEnrollmentNumber is a RangeDto type.