### PR TITLE
Fix V5 intervention model filtering

### DIFF
--- a/src/TransCelerate.SDR.Core/Utilities/Common/Constants.cs
+++ b/src/TransCelerate.SDR.Core/Utilities/Common/Constants.cs
@@ -101,6 +101,7 @@ namespace TransCelerate.SDR.Core.Utilities.Common
             public const string StudyPhaseStandardCodeDecode = "standardCode.decode";
             public const string StudyDesigns = "study.studyDesigns";
             public const string InterventionModel = "interventionModel.decode";
+            public const string InterventionModelV5 = "model.decode";
             public const string StudyIndicationsIndicationDescription = "studyIndications.indicationDescription";
             public const string StudyIndicationsIndicationDesc = "studyIndications.indicationDesc";
         }

--- a/src/TransCelerate.SDR.DataAccess/Filters/DataFilterCommon.cs
+++ b/src/TransCelerate.SDR.DataAccess/Filters/DataFilterCommon.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using TransCelerate.SDR.Core.Entities.Common;
+using TransCelerate.SDR.Core.Entities.StudyV5;
 using TransCelerate.SDR.Core.Utilities;
 using TransCelerate.SDR.Core.Utilities.Common;
 
@@ -418,7 +419,8 @@ namespace TransCelerate.SDR.DataAccess.Filters
             {
                 searchParameters.InterventionModel = Regex.Escape(searchParameters.InterventionModel);
                 filter &= builder.Or(
-                     builder.Regex($"{Constants.DbFilter.StudyDesigns}.{Constants.DbFilter.InterventionModel}", new BsonRegularExpression($"/{searchParameters.InterventionModel}/i"))
+                     builder.Regex($"{Constants.DbFilter.StudyDesigns}.{Constants.DbFilter.InterventionModel}", new BsonRegularExpression($"/{searchParameters.InterventionModel}/i")),
+                     builder.Regex($"{Constants.DbFilter.StudyDesigns}.{Constants.DbFilter.InterventionModelV5}", new BsonRegularExpression($"/{searchParameters.InterventionModel}/i"))
                     );
             }
 
@@ -436,10 +438,10 @@ namespace TransCelerate.SDR.DataAccess.Filters
 
             return filter;
         }
-        public static SortDefinition<SearchResponseEntity> GetSorterForSearchStudy(SearchParametersEntity searchParameters)
+        public static SortDefinition<Core.Entities.Common.SearchResponseEntity> GetSorterForSearchStudy(SearchParametersEntity searchParameters)
         {
-            SortDefinitionBuilder<SearchResponseEntity> builder = Builders<SearchResponseEntity>.Sort;
-            SortDefinition<SearchResponseEntity> sorter = builder.Descending(x => x.EntryDateTime);
+            SortDefinitionBuilder<Core.Entities.Common.SearchResponseEntity> builder = Builders<Core.Entities.Common.SearchResponseEntity>.Sort;
+            SortDefinition<Core.Entities.Common.SearchResponseEntity> sorter = builder.Descending(x => x.EntryDateTime);
 
             if (!String.IsNullOrWhiteSpace(searchParameters.Header))
             {
@@ -690,6 +692,23 @@ namespace TransCelerate.SDR.DataAccess.Filters
             //Filter for Indication
             if (!String.IsNullOrWhiteSpace(searchParameters.Indication))
                 filter &= builder.Where(x => x.Study.Versions[0].StudyDesigns.Any(x => x.Indications.Any(y => y.Description.ToLower().Contains(searchParameters.Indication.ToLower()))));
+
+            //Filter for Intervention Model
+            if (!String.IsNullOrWhiteSpace(searchParameters.InterventionModel))
+            {
+                filter &= builder.Or(
+                    builder.Where(x => x.Study.Versions[0].StudyDesigns.Any(design =>
+                        design.InstanceType == "InterventionalStudyDesign" &&
+                        ((InterventionalStudyDesignEntity)design).Model != null &&
+                        ((InterventionalStudyDesignEntity)design).Model.Decode.ToLower().Contains(searchParameters.InterventionModel.ToLower())
+                    )),
+                    builder.Where(x => x.Study.Versions[0].StudyDesigns.Any(design =>
+                        design.InstanceType == "ObservationalStudyDesign" &&
+                        ((ObservationalStudyDesignEntity)design).Model != null &&
+                        ((ObservationalStudyDesignEntity)design).Model.Decode.ToLower().Contains(searchParameters.InterventionModel.ToLower())
+                    ))
+                );
+            }
 
             //Filter for Study Phase
             if (!String.IsNullOrWhiteSpace(searchParameters.Phase))

--- a/src/TransCelerate.SDR.DataAccess/Filters/DataFilterCommon.cs
+++ b/src/TransCelerate.SDR.DataAccess/Filters/DataFilterCommon.cs
@@ -696,17 +696,11 @@ namespace TransCelerate.SDR.DataAccess.Filters
             //Filter for Intervention Model
             if (!String.IsNullOrWhiteSpace(searchParameters.InterventionModel))
             {
-                filter &= builder.Or(
-                    builder.Where(x => x.Study.Versions[0].StudyDesigns.Any(design =>
+                filter &= builder.Where(x => x.Study.Versions[0].StudyDesigns.Any(design =>
                         design.InstanceType == "InterventionalStudyDesign" &&
                         ((InterventionalStudyDesignEntity)design).Model != null &&
                         ((InterventionalStudyDesignEntity)design).Model.Decode.ToLower().Contains(searchParameters.InterventionModel.ToLower())
-                    )),
-                    builder.Where(x => x.Study.Versions[0].StudyDesigns.Any(design =>
-                        design.InstanceType == "ObservationalStudyDesign" &&
-                        ((ObservationalStudyDesignEntity)design).Model != null &&
-                        ((ObservationalStudyDesignEntity)design).Model.Decode.ToLower().Contains(searchParameters.InterventionModel.ToLower())
-                    ))
+                    )
                 );
             }
 


### PR DESCRIPTION
Fixes a bug where the search endpoint was not filtering by intervention model for usdm v4 searches.

The usdm v4 model has changed, and this moved the previous interventionModel property to a `Model` property on subclasses `InterventionalStudyDesign` and `ObservationalStudyDesign`. 

The filters have now been updated accordingly, and testing the endpoint in swagger it is now actually filtering by this field.